### PR TITLE
feat: add member and cohort domains

### DIFF
--- a/src/main/java/com/prography/backend/BackendApplication.java
+++ b/src/main/java/com/prography/backend/BackendApplication.java
@@ -2,7 +2,9 @@ package com.prography.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class BackendApplication {
 

--- a/src/main/java/com/prography/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/prography/backend/domain/auth/controller/AuthController.java
@@ -1,0 +1,42 @@
+package com.prography.backend.domain.auth.controller;
+
+import com.prography.backend.domain.auth.dto.request.LoginRequest;
+import com.prography.backend.domain.auth.service.AuthService;
+import com.prography.backend.domain.member.dto.response.MemberResponse;
+import com.prography.backend.domain.member.entity.MemberEntity;
+import com.prography.backend.domain.member.mapper.MemberMapper;
+import com.prography.backend.global.response.ApiResponse;
+import com.prography.backend.global.util.ResponseUtility;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * packageName    : com.prography.backend.domain.auth.controller<br>
+ * fileName       : AuthController.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 로그인 요청을 처리하는 컨트롤러 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+    private final AuthService authService;
+    private final MemberMapper memberMapper;
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<MemberResponse>> login(@RequestBody @Valid LoginRequest request) {
+        MemberEntity member = authService.login(request);
+        return ResponseUtility.success(memberMapper.toMemberResponse(member));
+    }
+}

--- a/src/main/java/com/prography/backend/domain/auth/dto/request/LoginRequest.java
+++ b/src/main/java/com/prography/backend/domain/auth/dto/request/LoginRequest.java
@@ -1,0 +1,25 @@
+package com.prography.backend.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+/**
+ * packageName    : com.prography.backend.domain.auth.dto.request<br>
+ * fileName       : LoginRequest.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 로그인 요청 DTO 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Getter
+public class LoginRequest {
+
+    @NotBlank(message = "loginId는 필수입니다.")
+    private String loginId;
+
+    @NotBlank(message = "password는 필수입니다.")
+    private String password;
+}

--- a/src/main/java/com/prography/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/com/prography/backend/domain/auth/service/AuthService.java
@@ -1,0 +1,47 @@
+package com.prography.backend.domain.auth.service;
+
+import com.prography.backend.domain.auth.dto.request.LoginRequest;
+import com.prography.backend.domain.member.entity.MemberEntity;
+import com.prography.backend.domain.member.entity.MemberStatus;
+import com.prography.backend.domain.member.service.MemberService;
+import com.prography.backend.global.common.StatusCode;
+import com.prography.backend.global.error.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * packageName    : com.prography.backend.domain.auth.service<br>
+ * fileName       : AuthService.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 인증 관련 비즈니스 로직을 처리하는 서비스 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final MemberService memberService;
+    private final PasswordEncoder passwordEncoder;
+
+    public MemberEntity login(LoginRequest request) {
+        MemberEntity member = memberService.findOptionalByLoginId(request.getLoginId())
+                .orElseThrow(() -> new CustomException(StatusCode.LOGIN_FAILED));
+
+        if (member.getStatus() == MemberStatus.WITHDRAWN) {
+            throw new CustomException(StatusCode.MEMBER_WITHDRAWN);
+        }
+
+        if (!passwordEncoder.matches(request.getPassword(), member.getPassword())) {
+            throw new CustomException(StatusCode.LOGIN_FAILED);
+        }
+
+        return member;
+    }
+}

--- a/src/main/java/com/prography/backend/domain/cohort/dto/response/CohortSummaryResponse.java
+++ b/src/main/java/com/prography/backend/domain/cohort/dto/response/CohortSummaryResponse.java
@@ -1,0 +1,26 @@
+package com.prography.backend.domain.cohort.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * packageName    : com.prography.backend.domain.cohort.dto.response<br>
+ * fileName       : CohortSummaryResponse.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 기수 요약 응답 DTO 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Getter
+@Builder
+public class CohortSummaryResponse {
+    private Long id;
+    private Integer generation;
+    private String name;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/prography/backend/domain/cohort/entity/CohortEntity.java
+++ b/src/main/java/com/prography/backend/domain/cohort/entity/CohortEntity.java
@@ -1,0 +1,37 @@
+package com.prography.backend.domain.cohort.entity;
+
+import com.prography.backend.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * packageName    : com.prography.backend.domain.cohort.entity<br>
+ * fileName       : CohortEntity.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 기수 엔티티 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Entity
+@Getter
+@Builder
+@Table(name = "tb_cohort")
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CohortEntity extends BaseEntity {
+
+    @Column(nullable = false)
+    private Integer generation;
+
+    @Column(nullable = false)
+    private String name;
+}

--- a/src/main/java/com/prography/backend/domain/cohort/mapper/CohortMapper.java
+++ b/src/main/java/com/prography/backend/domain/cohort/mapper/CohortMapper.java
@@ -1,0 +1,32 @@
+package com.prography.backend.domain.cohort.mapper;
+
+import com.prography.backend.domain.cohort.dto.response.CohortSummaryResponse;
+import com.prography.backend.domain.cohort.entity.CohortEntity;
+import org.springframework.stereotype.Component;
+
+/**
+ * packageName    : com.prography.backend.domain.cohort.mapper<br>
+ * fileName       : CohortMapper.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 기수 매핑을 담당하는 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Component
+public class CohortMapper {
+
+    public CohortSummaryResponse toSummaryResponse(CohortEntity cohort) {
+        if (cohort == null) {
+            return null;
+        }
+        return CohortSummaryResponse.builder()
+                .id(cohort.getId())
+                .generation(cohort.getGeneration())
+                .name(cohort.getName())
+                .createdAt(cohort.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/prography/backend/domain/cohort/repository/CohortRepository.java
+++ b/src/main/java/com/prography/backend/domain/cohort/repository/CohortRepository.java
@@ -1,0 +1,18 @@
+package com.prography.backend.domain.cohort.repository;
+
+import com.prography.backend.domain.cohort.entity.CohortEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * packageName    : com.prography.backend.domain.cohort.repository<br>
+ * fileName       : CohortRepository.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 기수 레포지토리 인터페이스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+public interface CohortRepository extends JpaRepository<CohortEntity, Long> {
+}

--- a/src/main/java/com/prography/backend/domain/cohort/service/CohortService.java
+++ b/src/main/java/com/prography/backend/domain/cohort/service/CohortService.java
@@ -1,0 +1,39 @@
+package com.prography.backend.domain.cohort.service;
+
+import com.prography.backend.domain.cohort.entity.CohortEntity;
+import com.prography.backend.domain.cohort.repository.CohortRepository;
+import com.prography.backend.global.common.StatusCode;
+import com.prography.backend.global.error.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * packageName    : com.prography.backend.domain.cohort.service<br>
+ * fileName       : CohortService.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 기수 관련 비즈니스 로직을 처리하는 서비스 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CohortService {
+
+    private final CohortRepository cohortRepository;
+
+    public List<CohortEntity> getCohorts() {
+        return cohortRepository.findAll();
+    }
+
+    public CohortEntity getById(Long id) {
+        return cohortRepository.findById(id)
+                .orElseThrow(() -> new CustomException(StatusCode.COHORT_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/prography/backend/domain/cohortmember/entity/CohortMemberEntity.java
+++ b/src/main/java/com/prography/backend/domain/cohortmember/entity/CohortMemberEntity.java
@@ -1,0 +1,68 @@
+package com.prography.backend.domain.cohortmember.entity;
+
+import com.prography.backend.domain.cohort.entity.CohortEntity;
+import com.prography.backend.domain.member.entity.MemberEntity;
+import com.prography.backend.domain.part.entity.PartEntity;
+import com.prography.backend.domain.team.entity.TeamEntity;
+import com.prography.backend.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * packageName    : com.prography.backend.domain.cohortmember.entity<br>
+ * fileName       : CohortMemberEntity.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 기수 회원 엔티티 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Entity
+@Getter
+@Builder
+@Table(name = "tb_cohort_member")
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CohortMemberEntity extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false)
+    private MemberEntity member;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "cohort_id", nullable = false)
+    private CohortEntity cohort;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "part_id")
+    private PartEntity part;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id")
+    private TeamEntity team;
+
+    @Column(nullable = false)
+    private Long deposit;
+
+    @Column(name = "excuse_count", nullable = false)
+    private Integer excuseCount;
+
+    public void updateDeposit(Long deposit) {
+        this.deposit = deposit;
+    }
+
+    public void updateExcuseCount(Integer excuseCount) {
+        this.excuseCount = excuseCount;
+    }
+}

--- a/src/main/java/com/prography/backend/domain/cohortmember/repository/CohortMemberRepository.java
+++ b/src/main/java/com/prography/backend/domain/cohortmember/repository/CohortMemberRepository.java
@@ -1,0 +1,18 @@
+package com.prography.backend.domain.cohortmember.repository;
+
+import com.prography.backend.domain.cohortmember.entity.CohortMemberEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * packageName    : com.prography.backend.domain.cohortmember.repository<br>
+ * fileName       : CohortMemberRepository.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 기수 회원 레포지토리 인터페이스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+public interface CohortMemberRepository extends JpaRepository<CohortMemberEntity, Long> {
+}

--- a/src/main/java/com/prography/backend/domain/cohortmember/service/CohortMemberService.java
+++ b/src/main/java/com/prography/backend/domain/cohortmember/service/CohortMemberService.java
@@ -1,0 +1,51 @@
+package com.prography.backend.domain.cohortmember.service;
+
+import com.prography.backend.domain.cohort.entity.CohortEntity;
+import com.prography.backend.domain.cohortmember.entity.CohortMemberEntity;
+import com.prography.backend.domain.cohortmember.repository.CohortMemberRepository;
+import com.prography.backend.domain.member.entity.MemberEntity;
+import com.prography.backend.domain.part.entity.PartEntity;
+import com.prography.backend.domain.team.entity.TeamEntity;
+import com.prography.backend.global.common.StatusCode;
+import com.prography.backend.global.error.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * packageName    : com.prography.backend.domain.cohortmember.service<br>
+ * fileName       : CohortMemberService.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 기수 회원 관련 비즈니스 로직을 처리하는 서비스 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CohortMemberService {
+
+    private final CohortMemberRepository cohortMemberRepository;
+
+    public CohortMemberEntity create(MemberEntity member, CohortEntity cohort, PartEntity part, TeamEntity team, Long deposit) {
+        CohortMemberEntity cohortMember = CohortMemberEntity.builder()
+                .member(member)
+                .cohort(cohort)
+                .part(part)
+                .team(team)
+                .deposit(deposit)
+                .excuseCount(0)
+                .build();
+
+        return cohortMemberRepository.save(cohortMember);
+    }
+
+    @Transactional(readOnly = true)
+    public CohortMemberEntity getById(Long id) {
+        return cohortMemberRepository.findById(id)
+                .orElseThrow(() -> new CustomException(StatusCode.COHORT_MEMBER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/prography/backend/domain/member/controller/MemberController.java
+++ b/src/main/java/com/prography/backend/domain/member/controller/MemberController.java
@@ -1,0 +1,40 @@
+package com.prography.backend.domain.member.controller;
+
+import com.prography.backend.domain.member.dto.response.MemberResponse;
+import com.prography.backend.domain.member.entity.MemberEntity;
+import com.prography.backend.domain.member.mapper.MemberMapper;
+import com.prography.backend.domain.member.service.MemberService;
+import com.prography.backend.global.response.ApiResponse;
+import com.prography.backend.global.util.ResponseUtility;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * packageName    : com.prography.backend.domain.member.controller<br>
+ * fileName       : MemberController.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 회원 조회 API를 처리하는 컨트롤러 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/members")
+public class MemberController {
+
+    private final MemberService memberService;
+    private final MemberMapper memberMapper;
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<MemberResponse>> getMember(@PathVariable Long id) {
+        MemberEntity member = memberService.getById(id);
+        return ResponseUtility.success(memberMapper.toMemberResponse(member));
+    }
+}

--- a/src/main/java/com/prography/backend/domain/member/dto/response/MemberResponse.java
+++ b/src/main/java/com/prography/backend/domain/member/dto/response/MemberResponse.java
@@ -1,0 +1,32 @@
+package com.prography.backend.domain.member.dto.response;
+
+import com.prography.backend.domain.member.entity.MemberRole;
+import com.prography.backend.domain.member.entity.MemberStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * packageName    : com.prography.backend.domain.member.dto.response<br>
+ * fileName       : MemberResponse.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 회원 응답 DTO 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Getter
+@Builder
+public class MemberResponse {
+    private Long id;
+    private String loginId;
+    private String name;
+    private String phone;
+    private MemberStatus status;
+    private MemberRole role;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/prography/backend/domain/member/entity/MemberEntity.java
+++ b/src/main/java/com/prography/backend/domain/member/entity/MemberEntity.java
@@ -1,0 +1,66 @@
+package com.prography.backend.domain.member.entity;
+
+import com.prography.backend.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * packageName    : com.prography.backend.domain.member.entity<br>
+ * fileName       : MemberEntity.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 회원 엔티티 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Entity
+@Getter
+@Builder
+@Table(name = "tb_member")
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberEntity extends BaseEntity {
+
+    @Column(name = "login_id", nullable = false, unique = true)
+    private String loginId;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String phone;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private MemberStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private MemberRole role;
+
+    public void updateProfile(String name, String phone) {
+        this.name = name;
+        this.phone = phone;
+    }
+
+    public void updatePassword(String password) {
+        this.password = password;
+    }
+
+    public void withdraw() {
+        this.status = MemberStatus.WITHDRAWN;
+    }
+}

--- a/src/main/java/com/prography/backend/domain/member/entity/MemberRole.java
+++ b/src/main/java/com/prography/backend/domain/member/entity/MemberRole.java
@@ -1,0 +1,22 @@
+package com.prography.backend.domain.member.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * packageName    : com.prography.backend.domain.member.entity<br>
+ * fileName       : MemberRole.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 회원 역할을 정의하는 enum 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Getter
+@RequiredArgsConstructor
+public enum MemberRole {
+    MEMBER,
+    ADMIN
+}

--- a/src/main/java/com/prography/backend/domain/member/entity/MemberStatus.java
+++ b/src/main/java/com/prography/backend/domain/member/entity/MemberStatus.java
@@ -1,0 +1,23 @@
+package com.prography.backend.domain.member.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * packageName    : com.prography.backend.domain.member.entity<br>
+ * fileName       : MemberStatus.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 회원 상태를 정의하는 enum 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Getter
+@RequiredArgsConstructor
+public enum MemberStatus {
+    ACTIVE,
+    INACTIVE,
+    WITHDRAWN
+}

--- a/src/main/java/com/prography/backend/domain/member/mapper/MemberMapper.java
+++ b/src/main/java/com/prography/backend/domain/member/mapper/MemberMapper.java
@@ -1,0 +1,36 @@
+package com.prography.backend.domain.member.mapper;
+
+import com.prography.backend.domain.member.dto.response.MemberResponse;
+import com.prography.backend.domain.member.entity.MemberEntity;
+import org.springframework.stereotype.Component;
+
+/**
+ * packageName    : com.prography.backend.domain.member.mapper<br>
+ * fileName       : MemberMapper.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 회원 매핑을 담당하는 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Component
+public class MemberMapper {
+
+    public MemberResponse toMemberResponse(MemberEntity member) {
+        if (member == null) {
+            return null;
+        }
+        return MemberResponse.builder()
+                .id(member.getId())
+                .loginId(member.getLoginId())
+                .name(member.getName())
+                .phone(member.getPhone())
+                .status(member.getStatus())
+                .role(member.getRole())
+                .createdAt(member.getCreatedAt())
+                .updatedAt(member.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/prography/backend/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/prography/backend/domain/member/repository/MemberRepository.java
@@ -1,0 +1,22 @@
+package com.prography.backend.domain.member.repository;
+
+import com.prography.backend.domain.member.entity.MemberEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+/**
+ * packageName    : com.prography.backend.domain.member.repository<br>
+ * fileName       : MemberRepository.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 회원 레포지토리 인터페이스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
+    Optional<MemberEntity> findByLoginId(String loginId);
+    boolean existsByLoginId(String loginId);
+}

--- a/src/main/java/com/prography/backend/domain/member/service/MemberService.java
+++ b/src/main/java/com/prography/backend/domain/member/service/MemberService.java
@@ -1,0 +1,68 @@
+package com.prography.backend.domain.member.service;
+
+import com.prography.backend.domain.member.entity.MemberEntity;
+import com.prography.backend.domain.member.entity.MemberRole;
+import com.prography.backend.domain.member.entity.MemberStatus;
+import com.prography.backend.domain.member.repository.MemberRepository;
+import com.prography.backend.global.common.StatusCode;
+import com.prography.backend.global.error.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+/**
+ * packageName    : com.prography.backend.domain.member.service<br>
+ * fileName       : MemberService.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 회원 관련 비즈니스 로직을 처리하는 서비스 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public MemberEntity createMember(String loginId, String encodedPassword, String name, String phone, MemberRole role) {
+        if (memberRepository.existsByLoginId(loginId)) {
+            throw new CustomException(StatusCode.DUPLICATE_LOGIN_ID);
+        }
+
+        MemberEntity member = MemberEntity.builder()
+                .loginId(loginId)
+                .password(encodedPassword)
+                .name(name)
+                .phone(phone)
+                .status(MemberStatus.ACTIVE)
+                .role(role)
+                .build();
+
+        return memberRepository.save(member);
+    }
+
+    @Transactional(readOnly = true)
+    public MemberEntity getById(Long id) {
+        return memberRepository.findById(id)
+                .orElseThrow(() -> new CustomException(StatusCode.MEMBER_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<MemberEntity> findOptionalByLoginId(String loginId) {
+        return memberRepository.findByLoginId(loginId);
+    }
+
+    public void withdrawMember(Long id) {
+        MemberEntity member = getById(id);
+        if (member.getStatus() == MemberStatus.WITHDRAWN) {
+            throw new CustomException(StatusCode.MEMBER_ALREADY_WITHDRAWN);
+        }
+        member.withdraw();
+    }
+}

--- a/src/main/java/com/prography/backend/domain/part/entity/PartEntity.java
+++ b/src/main/java/com/prography/backend/domain/part/entity/PartEntity.java
@@ -1,0 +1,42 @@
+package com.prography.backend.domain.part.entity;
+
+import com.prography.backend.domain.cohort.entity.CohortEntity;
+import com.prography.backend.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * packageName    : com.prography.backend.domain.part.entity<br>
+ * fileName       : PartEntity.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 파트 엔티티 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Entity
+@Getter
+@Builder
+@Table(name = "tb_part")
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PartEntity extends BaseEntity {
+
+    @Column(nullable = false)
+    private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "cohort_id", nullable = false)
+    private CohortEntity cohort;
+}

--- a/src/main/java/com/prography/backend/domain/part/repository/PartRepository.java
+++ b/src/main/java/com/prography/backend/domain/part/repository/PartRepository.java
@@ -1,0 +1,18 @@
+package com.prography.backend.domain.part.repository;
+
+import com.prography.backend.domain.part.entity.PartEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * packageName    : com.prography.backend.domain.part.repository<br>
+ * fileName       : PartRepository.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 파트 레포지토리 인터페이스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+public interface PartRepository extends JpaRepository<PartEntity, Long> {
+}

--- a/src/main/java/com/prography/backend/domain/part/service/PartService.java
+++ b/src/main/java/com/prography/backend/domain/part/service/PartService.java
@@ -1,0 +1,33 @@
+package com.prography.backend.domain.part.service;
+
+import com.prography.backend.domain.part.entity.PartEntity;
+import com.prography.backend.domain.part.repository.PartRepository;
+import com.prography.backend.global.common.StatusCode;
+import com.prography.backend.global.error.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * packageName    : com.prography.backend.domain.part.service<br>
+ * fileName       : PartService.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 파트 관련 비즈니스 로직을 처리하는 서비스 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class PartService {
+
+    private final PartRepository partRepository;
+
+    public PartEntity getById(Long id) {
+        return partRepository.findById(id)
+                .orElseThrow(() -> new CustomException(StatusCode.PART_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/prography/backend/domain/team/entity/TeamEntity.java
+++ b/src/main/java/com/prography/backend/domain/team/entity/TeamEntity.java
@@ -1,0 +1,42 @@
+package com.prography.backend.domain.team.entity;
+
+import com.prography.backend.domain.cohort.entity.CohortEntity;
+import com.prography.backend.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * packageName    : com.prography.backend.domain.team.entity<br>
+ * fileName       : TeamEntity.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 팀 엔티티 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Entity
+@Getter
+@Builder
+@Table(name = "tb_team")
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TeamEntity extends BaseEntity {
+
+    @Column(nullable = false)
+    private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "cohort_id", nullable = false)
+    private CohortEntity cohort;
+}

--- a/src/main/java/com/prography/backend/domain/team/repository/TeamRepository.java
+++ b/src/main/java/com/prography/backend/domain/team/repository/TeamRepository.java
@@ -1,0 +1,18 @@
+package com.prography.backend.domain.team.repository;
+
+import com.prography.backend.domain.team.entity.TeamEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * packageName    : com.prography.backend.domain.team.repository<br>
+ * fileName       : TeamRepository.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 팀 레포지토리 인터페이스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+public interface TeamRepository extends JpaRepository<TeamEntity, Long> {
+}

--- a/src/main/java/com/prography/backend/domain/team/service/TeamService.java
+++ b/src/main/java/com/prography/backend/domain/team/service/TeamService.java
@@ -1,0 +1,33 @@
+package com.prography.backend.domain.team.service;
+
+import com.prography.backend.domain.team.entity.TeamEntity;
+import com.prography.backend.domain.team.repository.TeamRepository;
+import com.prography.backend.global.common.StatusCode;
+import com.prography.backend.global.error.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * packageName    : com.prography.backend.domain.team.service<br>
+ * fileName       : TeamService.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 팀 관련 비즈니스 로직을 처리하는 서비스 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class TeamService {
+
+    private final TeamRepository teamRepository;
+
+    public TeamEntity getById(Long id) {
+        return teamRepository.findById(id)
+                .orElseThrow(() -> new CustomException(StatusCode.TEAM_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/prography/backend/global/common/BaseEntity.java
+++ b/src/main/java/com/prography/backend/global/common/BaseEntity.java
@@ -1,0 +1,44 @@
+package com.prography.backend.global.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+/**
+ * packageName    : com.prography.backend.global.common<br>
+ * fileName       : BaseEntity.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 공통 필드를 제공하는 베이스 엔티티입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false)
+    private Long id;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/prography/backend/global/config/PasswordConfig.java
+++ b/src/main/java/com/prography/backend/global/config/PasswordConfig.java
@@ -1,0 +1,26 @@
+package com.prography.backend.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/**
+ * packageName    : com.prography.backend.global.config<br>
+ * fileName       : PasswordConfig.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 비밀번호 인코더 설정 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Configuration
+public class PasswordConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder(12);
+    }
+}

--- a/src/test/java/com/prography/backend/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/prography/backend/domain/auth/service/AuthServiceTest.java
@@ -1,0 +1,99 @@
+package com.prography.backend.domain.auth.service;
+
+import com.prography.backend.domain.auth.dto.request.LoginRequest;
+import com.prography.backend.domain.member.entity.MemberEntity;
+import com.prography.backend.domain.member.entity.MemberRole;
+import com.prography.backend.domain.member.entity.MemberStatus;
+import com.prography.backend.domain.member.service.MemberService;
+import com.prography.backend.global.common.StatusCode;
+import com.prography.backend.global.error.CustomException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * packageName    : com.prography.backend.domain.auth.service<br>
+ * fileName       : AuthServiceTest.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 인증 서비스 테스트 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@SpringBootTest
+@Transactional
+class AuthServiceTest {
+
+    @Autowired
+    private AuthService authService;
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Test
+    void login_success() {
+        // Given
+        String rawPassword = "password123";
+        MemberEntity member = memberService.createMember("admin", passwordEncoder.encode(rawPassword), "관리자", "010-0000-0000", MemberRole.ADMIN);
+        LoginRequest request = buildRequest("admin", rawPassword);
+
+        // When
+        MemberEntity result = authService.login(request);
+
+        // Then
+        assertThat(result.getId()).isEqualTo(member.getId());
+        assertThat(result.getLoginId()).isEqualTo("admin");
+    }
+
+    @Test
+    void login_wrongPassword_throwsException() {
+        // Given
+        memberService.createMember("user1", passwordEncoder.encode("password123"), "홍길동", "010-1234-5678", MemberRole.MEMBER);
+        LoginRequest request = buildRequest("user1", "wrong");
+
+        // When & Then
+        assertThatThrownBy(() -> authService.login(request))
+                .isInstanceOf(CustomException.class)
+                .extracting("statusCode")
+                .isEqualTo(StatusCode.LOGIN_FAILED);
+    }
+
+    @Test
+    void login_withdrawnMember_throwsException() {
+        // Given
+        MemberEntity member = memberService.createMember("user2", passwordEncoder.encode("password123"), "성춘향", "010-2222-3333", MemberRole.MEMBER);
+        memberService.withdrawMember(member.getId());
+        LoginRequest request = buildRequest("user2", "password123");
+
+        // When & Then
+        assertThatThrownBy(() -> authService.login(request))
+                .isInstanceOf(CustomException.class)
+                .extracting("statusCode")
+                .isEqualTo(StatusCode.MEMBER_WITHDRAWN);
+    }
+
+    private LoginRequest buildRequest(String loginId, String password) {
+        LoginRequest request = new LoginRequest();
+        try {
+            java.lang.reflect.Field loginIdField = LoginRequest.class.getDeclaredField("loginId");
+            java.lang.reflect.Field passwordField = LoginRequest.class.getDeclaredField("password");
+            loginIdField.setAccessible(true);
+            passwordField.setAccessible(true);
+            loginIdField.set(request, loginId);
+            passwordField.set(request, password);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
+        return request;
+    }
+}

--- a/src/test/java/com/prography/backend/domain/cohort/service/CohortServiceTest.java
+++ b/src/test/java/com/prography/backend/domain/cohort/service/CohortServiceTest.java
@@ -1,0 +1,63 @@
+package com.prography.backend.domain.cohort.service;
+
+import com.prography.backend.domain.cohort.entity.CohortEntity;
+import com.prography.backend.domain.cohort.repository.CohortRepository;
+import com.prography.backend.global.common.StatusCode;
+import com.prography.backend.global.error.CustomException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * packageName    : com.prography.backend.domain.cohort.service<br>
+ * fileName       : CohortServiceTest.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 기수 서비스 테스트 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@SpringBootTest
+@Transactional
+class CohortServiceTest {
+
+    @Autowired
+    private CohortService cohortService;
+
+    @Autowired
+    private CohortRepository cohortRepository;
+
+    @Test
+    void getById_returnsCohort() {
+        // Given
+        CohortEntity cohort = cohortRepository.save(CohortEntity.builder()
+                .generation(11)
+                .name("11기")
+                .build());
+
+        // When
+        CohortEntity result = cohortService.getById(cohort.getId());
+
+        // Then
+        assertThat(result.getId()).isEqualTo(cohort.getId());
+        assertThat(result.getGeneration()).isEqualTo(11);
+    }
+
+    @Test
+    void getById_notFound_throwsException() {
+        // Given
+        Long unknownId = 999L;
+
+        // When & Then
+        assertThatThrownBy(() -> cohortService.getById(unknownId))
+                .isInstanceOf(CustomException.class)
+                .extracting("statusCode")
+                .isEqualTo(StatusCode.COHORT_NOT_FOUND);
+    }
+}

--- a/src/test/java/com/prography/backend/domain/cohortmember/service/CohortMemberServiceTest.java
+++ b/src/test/java/com/prography/backend/domain/cohortmember/service/CohortMemberServiceTest.java
@@ -1,0 +1,71 @@
+package com.prography.backend.domain.cohortmember.service;
+
+import com.prography.backend.domain.cohort.entity.CohortEntity;
+import com.prography.backend.domain.cohort.repository.CohortRepository;
+import com.prography.backend.domain.cohortmember.entity.CohortMemberEntity;
+import com.prography.backend.domain.member.entity.MemberEntity;
+import com.prography.backend.domain.member.entity.MemberRole;
+import com.prography.backend.domain.member.service.MemberService;
+import com.prography.backend.domain.part.entity.PartEntity;
+import com.prography.backend.domain.part.repository.PartRepository;
+import com.prography.backend.domain.team.entity.TeamEntity;
+import com.prography.backend.domain.team.repository.TeamRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * packageName    : com.prography.backend.domain.cohortmember.service<br>
+ * fileName       : CohortMemberServiceTest.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 기수 회원 서비스 테스트 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@SpringBootTest
+@Transactional
+class CohortMemberServiceTest {
+
+    @Autowired
+    private CohortMemberService cohortMemberService;
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private CohortRepository cohortRepository;
+
+    @Autowired
+    private PartRepository partRepository;
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Test
+    void create_createsCohortMember() {
+        // Given
+        MemberEntity member = memberService.createMember("user1", passwordEncoder.encode("password123"), "홍길동", "010-1234-5678", MemberRole.MEMBER);
+        CohortEntity cohort = cohortRepository.save(CohortEntity.builder().generation(11).name("11기").build());
+        PartEntity part = partRepository.save(PartEntity.builder().name("SERVER").cohort(cohort).build());
+        TeamEntity team = teamRepository.save(TeamEntity.builder().name("Team A").cohort(cohort).build());
+
+        // When
+        CohortMemberEntity cohortMember = cohortMemberService.create(member, cohort, part, team, 100_000L);
+
+        // Then
+        assertThat(cohortMember.getId()).isNotNull();
+        assertThat(cohortMember.getMember().getId()).isEqualTo(member.getId());
+        assertThat(cohortMember.getDeposit()).isEqualTo(100_000L);
+        assertThat(cohortMember.getExcuseCount()).isEqualTo(0);
+    }
+}

--- a/src/test/java/com/prography/backend/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/prography/backend/domain/member/service/MemberServiceTest.java
@@ -1,0 +1,80 @@
+package com.prography.backend.domain.member.service;
+
+import com.prography.backend.domain.member.entity.MemberEntity;
+import com.prography.backend.domain.member.entity.MemberRole;
+import com.prography.backend.domain.member.entity.MemberStatus;
+import com.prography.backend.global.common.StatusCode;
+import com.prography.backend.global.error.CustomException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * packageName    : com.prography.backend.domain.member.service<br>
+ * fileName       : MemberServiceTest.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 회원 서비스 테스트 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@SpringBootTest
+@Transactional
+class MemberServiceTest {
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Test
+    void createMember_savesMember() {
+        // Given
+        String loginId = "user1";
+        String password = passwordEncoder.encode("password123");
+
+        // When
+        MemberEntity member = memberService.createMember(loginId, password, "홍길동", "010-1234-5678", MemberRole.MEMBER);
+
+        // Then
+        assertThat(member.getId()).isNotNull();
+        assertThat(member.getLoginId()).isEqualTo(loginId);
+        assertThat(member.getStatus()).isEqualTo(MemberStatus.ACTIVE);
+        assertThat(member.getRole()).isEqualTo(MemberRole.MEMBER);
+    }
+
+    @Test
+    void createMember_duplicateLoginId_throwsException() {
+        // Given
+        String loginId = "user1";
+        String password = passwordEncoder.encode("password123");
+        memberService.createMember(loginId, password, "홍길동", "010-1234-5678", MemberRole.MEMBER);
+
+        // When & Then
+        assertThatThrownBy(() -> memberService.createMember(loginId, password, "홍길동", "010-0000-0000", MemberRole.MEMBER))
+                .isInstanceOf(CustomException.class)
+                .extracting("statusCode")
+                .isEqualTo(StatusCode.DUPLICATE_LOGIN_ID);
+    }
+
+    @Test
+    void withdrawMember_updatesStatus() {
+        // Given
+        MemberEntity member = memberService.createMember("user2", passwordEncoder.encode("password123"), "이몽룡", "010-2222-3333", MemberRole.MEMBER);
+
+        // When
+        memberService.withdrawMember(member.getId());
+
+        // Then
+        MemberEntity updated = memberService.getById(member.getId());
+        assertThat(updated.getStatus()).isEqualTo(MemberStatus.WITHDRAWN);
+    }
+}

--- a/src/test/java/com/prography/backend/domain/part/service/PartServiceTest.java
+++ b/src/test/java/com/prography/backend/domain/part/service/PartServiceTest.java
@@ -1,0 +1,72 @@
+package com.prography.backend.domain.part.service;
+
+import com.prography.backend.domain.cohort.entity.CohortEntity;
+import com.prography.backend.domain.cohort.repository.CohortRepository;
+import com.prography.backend.domain.part.entity.PartEntity;
+import com.prography.backend.domain.part.repository.PartRepository;
+import com.prography.backend.global.common.StatusCode;
+import com.prography.backend.global.error.CustomException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * packageName    : com.prography.backend.domain.part.service<br>
+ * fileName       : PartServiceTest.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 파트 서비스 테스트 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@SpringBootTest
+@Transactional
+class PartServiceTest {
+
+    @Autowired
+    private PartService partService;
+
+    @Autowired
+    private PartRepository partRepository;
+
+    @Autowired
+    private CohortRepository cohortRepository;
+
+    @Test
+    void getById_returnsPart() {
+        // Given
+        CohortEntity cohort = cohortRepository.save(CohortEntity.builder()
+                .generation(11)
+                .name("11기")
+                .build());
+        PartEntity part = partRepository.save(PartEntity.builder()
+                .name("SERVER")
+                .cohort(cohort)
+                .build());
+
+        // When
+        PartEntity result = partService.getById(part.getId());
+
+        // Then
+        assertThat(result.getId()).isEqualTo(part.getId());
+        assertThat(result.getName()).isEqualTo("SERVER");
+    }
+
+    @Test
+    void getById_notFound_throwsException() {
+        // Given
+        Long unknownId = 999L;
+
+        // When & Then
+        assertThatThrownBy(() -> partService.getById(unknownId))
+                .isInstanceOf(CustomException.class)
+                .extracting("statusCode")
+                .isEqualTo(StatusCode.PART_NOT_FOUND);
+    }
+}

--- a/src/test/java/com/prography/backend/domain/team/service/TeamServiceTest.java
+++ b/src/test/java/com/prography/backend/domain/team/service/TeamServiceTest.java
@@ -1,0 +1,72 @@
+package com.prography.backend.domain.team.service;
+
+import com.prography.backend.domain.cohort.entity.CohortEntity;
+import com.prography.backend.domain.cohort.repository.CohortRepository;
+import com.prography.backend.domain.team.entity.TeamEntity;
+import com.prography.backend.domain.team.repository.TeamRepository;
+import com.prography.backend.global.common.StatusCode;
+import com.prography.backend.global.error.CustomException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * packageName    : com.prography.backend.domain.team.service<br>
+ * fileName       : TeamServiceTest.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 팀 서비스 테스트 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@SpringBootTest
+@Transactional
+class TeamServiceTest {
+
+    @Autowired
+    private TeamService teamService;
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Autowired
+    private CohortRepository cohortRepository;
+
+    @Test
+    void getById_returnsTeam() {
+        // Given
+        CohortEntity cohort = cohortRepository.save(CohortEntity.builder()
+                .generation(11)
+                .name("11기")
+                .build());
+        TeamEntity team = teamRepository.save(TeamEntity.builder()
+                .name("Team A")
+                .cohort(cohort)
+                .build());
+
+        // When
+        TeamEntity result = teamService.getById(team.getId());
+
+        // Then
+        assertThat(result.getId()).isEqualTo(team.getId());
+        assertThat(result.getName()).isEqualTo("Team A");
+    }
+
+    @Test
+    void getById_notFound_throwsException() {
+        // Given
+        Long unknownId = 999L;
+
+        // When & Then
+        assertThatThrownBy(() -> teamService.getById(unknownId))
+                .isInstanceOf(CustomException.class)
+                .extracting("statusCode")
+                .isEqualTo(StatusCode.TEAM_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #3 

  ## 📝 작업 내용
  - Member/Auth 도메인 기본 구조 추가 (컨트롤러/서비스/매퍼/DTO)
  - Cohort/Part/Team/CohortMember 엔티티·서비스·레포 추가
  - Given/When/Then 방식 단위 테스트 추가
  - BaseEntity + JPA Auditing 적용

  ## ✅ 테스트 결과
  - [x] ./gradlew test