### PR TITLE
feat: add cohort admin query APIs and sorting

### DIFF
--- a/src/main/java/com/prography/backend/domain/cohort/controller/CohortController.java
+++ b/src/main/java/com/prography/backend/domain/cohort/controller/CohortController.java
@@ -1,0 +1,44 @@
+package com.prography.backend.domain.cohort.controller;
+
+import com.prography.backend.domain.cohort.dto.response.CohortDetailResponse;
+import com.prography.backend.domain.cohort.dto.response.CohortSummaryResponse;
+import com.prography.backend.domain.cohort.service.CohortFacadeService;
+import com.prography.backend.global.response.ApiResponse;
+import com.prography.backend.global.util.ResponseUtility;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * packageName    : com.prography.backend.domain.cohort.controller<br>
+ * fileName       : CohortController.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 기수 조회 API를 처리하는 컨트롤러 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/cohorts")
+public class CohortController {
+
+    private final CohortFacadeService cohortFacadeService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<CohortSummaryResponse>>> getCohorts() {
+        return ResponseUtility.success(cohortFacadeService.getCohortSummaries());
+    }
+
+    @GetMapping("/{cohortId}")
+    public ResponseEntity<ApiResponse<CohortDetailResponse>> getCohortDetail(@PathVariable Long cohortId) {
+        return ResponseUtility.success(cohortFacadeService.getCohortDetail(cohortId));
+    }
+}

--- a/src/main/java/com/prography/backend/domain/cohort/dto/response/CohortDetailResponse.java
+++ b/src/main/java/com/prography/backend/domain/cohort/dto/response/CohortDetailResponse.java
@@ -1,0 +1,31 @@
+package com.prography.backend.domain.cohort.dto.response;
+
+import com.prography.backend.domain.part.dto.response.PartSummaryResponse;
+import com.prography.backend.domain.team.dto.response.TeamSummaryResponse;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * packageName    : com.prography.backend.domain.cohort.dto.response<br>
+ * fileName       : CohortDetailResponse.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 기수 상세 응답 DTO 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Getter
+@Builder
+public class CohortDetailResponse {
+    private Long id;
+    private Integer generation;
+    private String name;
+    private List<PartSummaryResponse> parts;
+    private List<TeamSummaryResponse> teams;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/prography/backend/domain/cohort/mapper/CohortMapper.java
+++ b/src/main/java/com/prography/backend/domain/cohort/mapper/CohortMapper.java
@@ -1,8 +1,19 @@
 package com.prography.backend.domain.cohort.mapper;
 
+import com.prography.backend.domain.cohort.dto.response.CohortDetailResponse;
 import com.prography.backend.domain.cohort.dto.response.CohortSummaryResponse;
 import com.prography.backend.domain.cohort.entity.CohortEntity;
+import com.prography.backend.domain.part.dto.response.PartSummaryResponse;
+import com.prography.backend.domain.part.entity.PartEntity;
+import com.prography.backend.domain.part.mapper.PartMapper;
+import com.prography.backend.domain.team.dto.response.TeamSummaryResponse;
+import com.prography.backend.domain.team.entity.TeamEntity;
+import com.prography.backend.domain.team.mapper.TeamMapper;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * packageName    : com.prography.backend.domain.cohort.mapper<br>
@@ -16,7 +27,11 @@ import org.springframework.stereotype.Component;
  * 2026-02-24         cod0216             최초생성<br>
  */
 @Component
+@RequiredArgsConstructor
 public class CohortMapper {
+
+    private final PartMapper partMapper;
+    private final TeamMapper teamMapper;
 
     public CohortSummaryResponse toSummaryResponse(CohortEntity cohort) {
         if (cohort == null) {
@@ -28,5 +43,37 @@ public class CohortMapper {
                 .name(cohort.getName())
                 .createdAt(cohort.getCreatedAt())
                 .build();
+    }
+
+    public CohortDetailResponse toDetailResponse(CohortEntity cohort, List<PartEntity> parts, List<TeamEntity> teams) {
+        if (cohort == null) {
+            return null;
+        }
+        return CohortDetailResponse.builder()
+                .id(cohort.getId())
+                .generation(cohort.getGeneration())
+                .name(cohort.getName())
+                .parts(mapParts(parts))
+                .teams(mapTeams(teams))
+                .createdAt(cohort.getCreatedAt())
+                .build();
+    }
+
+    private List<PartSummaryResponse> mapParts(List<PartEntity> parts) {
+        if (parts == null) {
+            return List.of();
+        }
+        return parts.stream()
+                .map(partMapper::toSummaryResponse)
+                .collect(Collectors.toList());
+    }
+
+    private List<TeamSummaryResponse> mapTeams(List<TeamEntity> teams) {
+        if (teams == null) {
+            return List.of();
+        }
+        return teams.stream()
+                .map(teamMapper::toSummaryResponse)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/prography/backend/domain/cohort/service/CohortFacadeService.java
+++ b/src/main/java/com/prography/backend/domain/cohort/service/CohortFacadeService.java
@@ -1,0 +1,51 @@
+package com.prography.backend.domain.cohort.service;
+
+import com.prography.backend.domain.cohort.dto.response.CohortDetailResponse;
+import com.prography.backend.domain.cohort.dto.response.CohortSummaryResponse;
+import com.prography.backend.domain.cohort.entity.CohortEntity;
+import com.prography.backend.domain.cohort.mapper.CohortMapper;
+import com.prography.backend.domain.part.entity.PartEntity;
+import com.prography.backend.domain.part.service.PartService;
+import com.prography.backend.domain.team.entity.TeamEntity;
+import com.prography.backend.domain.team.service.TeamService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * packageName    : com.prography.backend.domain.cohort.service<br>
+ * fileName       : CohortFacadeService.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 기수 관련 복합 조회를 제공하는 파사드 서비스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CohortFacadeService {
+
+    private final CohortService cohortService;
+    private final PartService partService;
+    private final TeamService teamService;
+    private final CohortMapper cohortMapper;
+
+    public List<CohortSummaryResponse> getCohortSummaries() {
+        return cohortService.getCohorts().stream()
+                .map(cohortMapper::toSummaryResponse)
+                .collect(Collectors.toList());
+    }
+
+    public CohortDetailResponse getCohortDetail(Long cohortId) {
+        CohortEntity cohort = cohortService.getById(cohortId);
+        List<PartEntity> parts = partService.getByCohortId(cohortId);
+        List<TeamEntity> teams = teamService.getByCohortId(cohortId);
+        return cohortMapper.toDetailResponse(cohort, parts, teams);
+    }
+}

--- a/src/main/java/com/prography/backend/domain/cohort/service/CohortService.java
+++ b/src/main/java/com/prography/backend/domain/cohort/service/CohortService.java
@@ -5,6 +5,7 @@ import com.prography.backend.domain.cohort.repository.CohortRepository;
 import com.prography.backend.global.common.StatusCode;
 import com.prography.backend.global.error.CustomException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,7 +30,7 @@ public class CohortService {
     private final CohortRepository cohortRepository;
 
     public List<CohortEntity> getCohorts() {
-        return cohortRepository.findAll();
+        return cohortRepository.findAll(Sort.by(Sort.Direction.ASC, "generation"));
     }
 
     public CohortEntity getById(Long id) {

--- a/src/main/java/com/prography/backend/domain/part/dto/response/PartSummaryResponse.java
+++ b/src/main/java/com/prography/backend/domain/part/dto/response/PartSummaryResponse.java
@@ -1,0 +1,22 @@
+package com.prography.backend.domain.part.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * packageName    : com.prography.backend.domain.part.dto.response<br>
+ * fileName       : PartSummaryResponse.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 파트 요약 응답 DTO 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Getter
+@Builder
+public class PartSummaryResponse {
+    private Long id;
+    private String name;
+}

--- a/src/main/java/com/prography/backend/domain/part/mapper/PartMapper.java
+++ b/src/main/java/com/prography/backend/domain/part/mapper/PartMapper.java
@@ -1,0 +1,30 @@
+package com.prography.backend.domain.part.mapper;
+
+import com.prography.backend.domain.part.dto.response.PartSummaryResponse;
+import com.prography.backend.domain.part.entity.PartEntity;
+import org.springframework.stereotype.Component;
+
+/**
+ * packageName    : com.prography.backend.domain.part.mapper<br>
+ * fileName       : PartMapper.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 파트 매핑을 담당하는 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Component
+public class PartMapper {
+
+    public PartSummaryResponse toSummaryResponse(PartEntity part) {
+        if (part == null) {
+            return null;
+        }
+        return PartSummaryResponse.builder()
+                .id(part.getId())
+                .name(part.getName())
+                .build();
+    }
+}

--- a/src/main/java/com/prography/backend/domain/part/repository/PartRepository.java
+++ b/src/main/java/com/prography/backend/domain/part/repository/PartRepository.java
@@ -3,6 +3,8 @@ package com.prography.backend.domain.part.repository;
 import com.prography.backend.domain.part.entity.PartEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 /**
  * packageName    : com.prography.backend.domain.part.repository<br>
  * fileName       : PartRepository.java<br>
@@ -15,4 +17,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
  * 2026-02-24         cod0216             최초생성<br>
  */
 public interface PartRepository extends JpaRepository<PartEntity, Long> {
+    List<PartEntity> findByCohortIdOrderByNameAsc(Long cohortId);
 }

--- a/src/main/java/com/prography/backend/domain/part/service/PartService.java
+++ b/src/main/java/com/prography/backend/domain/part/service/PartService.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 /**
  * packageName    : com.prography.backend.domain.part.service<br>
  * fileName       : PartService.java<br>
@@ -29,5 +31,9 @@ public class PartService {
     public PartEntity getById(Long id) {
         return partRepository.findById(id)
                 .orElseThrow(() -> new CustomException(StatusCode.PART_NOT_FOUND));
+    }
+
+    public List<PartEntity> getByCohortId(Long cohortId) {
+        return partRepository.findByCohortIdOrderByNameAsc(cohortId);
     }
 }

--- a/src/main/java/com/prography/backend/domain/team/dto/response/TeamSummaryResponse.java
+++ b/src/main/java/com/prography/backend/domain/team/dto/response/TeamSummaryResponse.java
@@ -1,0 +1,22 @@
+package com.prography.backend.domain.team.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * packageName    : com.prography.backend.domain.team.dto.response<br>
+ * fileName       : TeamSummaryResponse.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 팀 요약 응답 DTO 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Getter
+@Builder
+public class TeamSummaryResponse {
+    private Long id;
+    private String name;
+}

--- a/src/main/java/com/prography/backend/domain/team/mapper/TeamMapper.java
+++ b/src/main/java/com/prography/backend/domain/team/mapper/TeamMapper.java
@@ -1,0 +1,30 @@
+package com.prography.backend.domain.team.mapper;
+
+import com.prography.backend.domain.team.dto.response.TeamSummaryResponse;
+import com.prography.backend.domain.team.entity.TeamEntity;
+import org.springframework.stereotype.Component;
+
+/**
+ * packageName    : com.prography.backend.domain.team.mapper<br>
+ * fileName       : TeamMapper.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 팀 매핑을 담당하는 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Component
+public class TeamMapper {
+
+    public TeamSummaryResponse toSummaryResponse(TeamEntity team) {
+        if (team == null) {
+            return null;
+        }
+        return TeamSummaryResponse.builder()
+                .id(team.getId())
+                .name(team.getName())
+                .build();
+    }
+}

--- a/src/main/java/com/prography/backend/domain/team/repository/TeamRepository.java
+++ b/src/main/java/com/prography/backend/domain/team/repository/TeamRepository.java
@@ -3,6 +3,8 @@ package com.prography.backend.domain.team.repository;
 import com.prography.backend.domain.team.entity.TeamEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 /**
  * packageName    : com.prography.backend.domain.team.repository<br>
  * fileName       : TeamRepository.java<br>
@@ -15,4 +17,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
  * 2026-02-24         cod0216             최초생성<br>
  */
 public interface TeamRepository extends JpaRepository<TeamEntity, Long> {
+    List<TeamEntity> findByCohortIdOrderByNameAsc(Long cohortId);
 }

--- a/src/main/java/com/prography/backend/domain/team/service/TeamService.java
+++ b/src/main/java/com/prography/backend/domain/team/service/TeamService.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 /**
  * packageName    : com.prography.backend.domain.team.service<br>
  * fileName       : TeamService.java<br>
@@ -29,5 +31,9 @@ public class TeamService {
     public TeamEntity getById(Long id) {
         return teamRepository.findById(id)
                 .orElseThrow(() -> new CustomException(StatusCode.TEAM_NOT_FOUND));
+    }
+
+    public List<TeamEntity> getByCohortId(Long cohortId) {
+        return teamRepository.findByCohortIdOrderByNameAsc(cohortId);
     }
 }

--- a/src/test/java/com/prography/backend/domain/cohort/service/CohortFacadeServiceTest.java
+++ b/src/test/java/com/prography/backend/domain/cohort/service/CohortFacadeServiceTest.java
@@ -1,0 +1,86 @@
+package com.prography.backend.domain.cohort.service;
+
+import com.prography.backend.domain.cohort.dto.response.CohortDetailResponse;
+import com.prography.backend.domain.cohort.dto.response.CohortSummaryResponse;
+import com.prography.backend.domain.cohort.entity.CohortEntity;
+import com.prography.backend.domain.cohort.repository.CohortRepository;
+import com.prography.backend.domain.part.entity.PartEntity;
+import com.prography.backend.domain.part.repository.PartRepository;
+import com.prography.backend.domain.team.entity.TeamEntity;
+import com.prography.backend.domain.team.repository.TeamRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * packageName    : com.prography.backend.domain.cohort.service<br>
+ * fileName       : CohortFacadeServiceTest.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 기수 파사드 서비스 테스트 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@SpringBootTest
+@Transactional
+class CohortFacadeServiceTest {
+
+    @Autowired
+    private CohortFacadeService cohortFacadeService;
+
+    @Autowired
+    private CohortRepository cohortRepository;
+
+    @Autowired
+    private PartRepository partRepository;
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Test
+    void getCohortSummaries_returnsAllCohorts() {
+        // Given
+        cohortRepository.save(CohortEntity.builder().generation(10).name("10기").build());
+        cohortRepository.save(CohortEntity.builder().generation(11).name("11기").build());
+
+        // When
+        List<CohortSummaryResponse> result = cohortFacadeService.getCohortSummaries();
+
+        // Then
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting("generation")
+                .containsExactly(10, 11);
+    }
+
+    @Test
+    void getCohortDetail_returnsPartsAndTeams() {
+        // Given
+        CohortEntity cohort = cohortRepository.save(CohortEntity.builder().generation(11).name("11기").build());
+        CohortEntity otherCohort = cohortRepository.save(CohortEntity.builder().generation(10).name("10기").build());
+
+        partRepository.save(PartEntity.builder().name("SERVER").cohort(cohort).build());
+        partRepository.save(PartEntity.builder().name("WEB").cohort(cohort).build());
+        partRepository.save(PartEntity.builder().name("iOS").cohort(otherCohort).build());
+
+        teamRepository.save(TeamEntity.builder().name("Team A").cohort(cohort).build());
+        teamRepository.save(TeamEntity.builder().name("Team B").cohort(cohort).build());
+        teamRepository.save(TeamEntity.builder().name("Team X").cohort(otherCohort).build());
+
+        // When
+        CohortDetailResponse detail = cohortFacadeService.getCohortDetail(cohort.getId());
+
+        // Then
+        assertThat(detail.getId()).isEqualTo(cohort.getId());
+        assertThat(detail.getParts()).extracting("name")
+                .containsExactly("SERVER", "WEB");
+        assertThat(detail.getTeams()).extracting("name")
+                .containsExactly("Team A", "Team B");
+    }
+}

--- a/src/test/java/com/prography/backend/domain/part/service/PartServiceTest.java
+++ b/src/test/java/com/prography/backend/domain/part/service/PartServiceTest.java
@@ -69,4 +69,29 @@ class PartServiceTest {
                 .extracting("statusCode")
                 .isEqualTo(StatusCode.PART_NOT_FOUND);
     }
+
+    @Test
+    void getByCohortId_returnsParts() {
+        // Given
+        CohortEntity cohort = cohortRepository.save(CohortEntity.builder()
+                .generation(11)
+                .name("11기")
+                .build());
+        PartEntity part1 = partRepository.save(PartEntity.builder()
+                .name("SERVER")
+                .cohort(cohort)
+                .build());
+        PartEntity part2 = partRepository.save(PartEntity.builder()
+                .name("WEB")
+                .cohort(cohort)
+                .build());
+
+        // When
+        var parts = partService.getByCohortId(cohort.getId());
+
+        // Then
+        assertThat(parts).hasSize(2);
+        assertThat(parts).extracting("id")
+                .containsExactly(part1.getId(), part2.getId());
+    }
 }

--- a/src/test/java/com/prography/backend/domain/team/service/TeamServiceTest.java
+++ b/src/test/java/com/prography/backend/domain/team/service/TeamServiceTest.java
@@ -69,4 +69,29 @@ class TeamServiceTest {
                 .extracting("statusCode")
                 .isEqualTo(StatusCode.TEAM_NOT_FOUND);
     }
+
+    @Test
+    void getByCohortId_returnsTeams() {
+        // Given
+        CohortEntity cohort = cohortRepository.save(CohortEntity.builder()
+                .generation(11)
+                .name("11기")
+                .build());
+        TeamEntity team1 = teamRepository.save(TeamEntity.builder()
+                .name("Team A")
+                .cohort(cohort)
+                .build());
+        TeamEntity team2 = teamRepository.save(TeamEntity.builder()
+                .name("Team B")
+                .cohort(cohort)
+                .build());
+
+        // When
+        var teams = teamService.getByCohortId(cohort.getId());
+
+        // Then
+        assertThat(teams).hasSize(2);
+        assertThat(teams).extracting("id")
+                .containsExactly(team1.getId(), team2.getId());
+    }
 }


### PR DESCRIPTION
 ## #️⃣ 관련 이슈
- #5 

  ## 📝 작업 내용
  - 기수 목록/상세 조회 API 추가
  - 파트/팀 요약 DTO 및 매퍼 추가
  - 정렬 기준 적용 (Cohort: generation ASC, Part/Team: name ASC)
  - Facade 서비스 + 테스트 추가
  - Given/When/Then 테스트 통과