### PR TITLE
feat: admin member/deposit/attendance features

### DIFF
--- a/src/main/java/com/prography/backend/domain/attendance/controller/AdminAttendanceController.java
+++ b/src/main/java/com/prography/backend/domain/attendance/controller/AdminAttendanceController.java
@@ -1,0 +1,70 @@
+package com.prography.backend.domain.attendance.controller;
+
+import com.prography.backend.domain.attendance.dto.request.AdminAttendanceRegisterRequest;
+import com.prography.backend.domain.attendance.dto.request.AdminAttendanceUpdateRequest;
+import com.prography.backend.domain.attendance.dto.response.AdminMemberAttendanceDetailResponse;
+import com.prography.backend.domain.attendance.dto.response.AdminSessionAttendanceSummaryResponse;
+import com.prography.backend.domain.attendance.dto.response.AdminSessionAttendancesResponse;
+import com.prography.backend.domain.attendance.dto.response.AttendanceResponse;
+import com.prography.backend.domain.attendance.service.AdminAttendanceFacadeService;
+import com.prography.backend.global.response.ApiResponse;
+import com.prography.backend.global.util.ResponseUtility;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * packageName    : com.prography.backend.domain.attendance.controller<br>
+ * fileName       : AdminAttendanceController.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 관리자 출결 API를 처리하는 컨트롤러 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/attendances")
+public class AdminAttendanceController {
+
+    private final AdminAttendanceFacadeService adminAttendanceFacadeService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<AttendanceResponse>> registerAttendance(@RequestBody @Valid AdminAttendanceRegisterRequest request) {
+        return ResponseUtility.created(adminAttendanceFacadeService.registerAttendance(request));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiResponse<AttendanceResponse>> updateAttendance(
+            @PathVariable Long id,
+            @RequestBody @Valid AdminAttendanceUpdateRequest request
+    ) {
+        return ResponseUtility.success(adminAttendanceFacadeService.updateAttendance(id, request));
+    }
+
+    @GetMapping("/sessions/{sessionId}/summary")
+    public ResponseEntity<ApiResponse<List<AdminSessionAttendanceSummaryResponse>>> getSessionSummary(@PathVariable Long sessionId) {
+        return ResponseUtility.success(adminAttendanceFacadeService.getSessionSummary(sessionId));
+    }
+
+    @GetMapping("/members/{memberId}")
+    public ResponseEntity<ApiResponse<AdminMemberAttendanceDetailResponse>> getMemberAttendanceDetail(@PathVariable Long memberId) {
+        return ResponseUtility.success(adminAttendanceFacadeService.getMemberAttendanceDetail(memberId));
+    }
+
+    @GetMapping("/sessions/{sessionId}")
+    public ResponseEntity<ApiResponse<AdminSessionAttendancesResponse>> getSessionAttendances(@PathVariable Long sessionId) {
+        return ResponseUtility.success(adminAttendanceFacadeService.getSessionAttendances(sessionId));
+    }
+}

--- a/src/main/java/com/prography/backend/domain/attendance/dto/request/AdminAttendanceRegisterRequest.java
+++ b/src/main/java/com/prography/backend/domain/attendance/dto/request/AdminAttendanceRegisterRequest.java
@@ -1,0 +1,35 @@
+package com.prography.backend.domain.attendance.dto.request;
+
+import com.prography.backend.domain.attendance.entity.AttendanceStatus;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+/**
+ * packageName    : com.prography.backend.domain.attendance.dto.request<br>
+ * fileName       : AdminAttendanceRegisterRequest.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 관리자 출결 등록 요청 DTO 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Getter
+public class AdminAttendanceRegisterRequest {
+
+    @NotNull(message = "sessionId는 필수입니다.")
+    private Long sessionId;
+
+    @NotNull(message = "memberId는 필수입니다.")
+    private Long memberId;
+
+    @NotNull(message = "status는 필수입니다.")
+    private AttendanceStatus status;
+
+    @Min(value = 0, message = "lateMinutes는 0 이상이어야 합니다.")
+    private Integer lateMinutes;
+
+    private String reason;
+}

--- a/src/main/java/com/prography/backend/domain/attendance/dto/request/AdminAttendanceUpdateRequest.java
+++ b/src/main/java/com/prography/backend/domain/attendance/dto/request/AdminAttendanceUpdateRequest.java
@@ -1,0 +1,29 @@
+package com.prography.backend.domain.attendance.dto.request;
+
+import com.prography.backend.domain.attendance.entity.AttendanceStatus;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+/**
+ * packageName    : com.prography.backend.domain.attendance.dto.request<br>
+ * fileName       : AdminAttendanceUpdateRequest.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 관리자 출결 수정 요청 DTO 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Getter
+public class AdminAttendanceUpdateRequest {
+
+    @NotNull(message = "status는 필수입니다.")
+    private AttendanceStatus status;
+
+    @Min(value = 0, message = "lateMinutes는 0 이상이어야 합니다.")
+    private Integer lateMinutes;
+
+    private String reason;
+}

--- a/src/main/java/com/prography/backend/domain/attendance/dto/response/AdminMemberAttendanceDetailResponse.java
+++ b/src/main/java/com/prography/backend/domain/attendance/dto/response/AdminMemberAttendanceDetailResponse.java
@@ -1,0 +1,30 @@
+package com.prography.backend.domain.attendance.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * packageName    : com.prography.backend.domain.attendance.dto.response<br>
+ * fileName       : AdminMemberAttendanceDetailResponse.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 관리자 회원 출결 상세 응답 DTO 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Getter
+@Builder
+public class AdminMemberAttendanceDetailResponse {
+    private Long memberId;
+    private String memberName;
+    private Integer generation;
+    private String partName;
+    private String teamName;
+    private Long deposit;
+    private Integer excuseCount;
+    private List<AttendanceResponse> attendances;
+}

--- a/src/main/java/com/prography/backend/domain/attendance/dto/response/AdminSessionAttendanceSummaryResponse.java
+++ b/src/main/java/com/prography/backend/domain/attendance/dto/response/AdminSessionAttendanceSummaryResponse.java
@@ -1,0 +1,28 @@
+package com.prography.backend.domain.attendance.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * packageName    : com.prography.backend.domain.attendance.dto.response<br>
+ * fileName       : AdminSessionAttendanceSummaryResponse.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 관리자 일정별 회원 출결 요약 응답 DTO 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Getter
+@Builder
+public class AdminSessionAttendanceSummaryResponse {
+    private Long memberId;
+    private String memberName;
+    private int present;
+    private int absent;
+    private int late;
+    private int excused;
+    private Long totalPenalty;
+    private Long deposit;
+}

--- a/src/main/java/com/prography/backend/domain/attendance/dto/response/AdminSessionAttendancesResponse.java
+++ b/src/main/java/com/prography/backend/domain/attendance/dto/response/AdminSessionAttendancesResponse.java
@@ -1,0 +1,25 @@
+package com.prography.backend.domain.attendance.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * packageName    : com.prography.backend.domain.attendance.dto.response<br>
+ * fileName       : AdminSessionAttendancesResponse.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 관리자 일정별 출결 목록 응답 DTO 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Getter
+@Builder
+public class AdminSessionAttendancesResponse {
+    private Long sessionId;
+    private String sessionTitle;
+    private List<AttendanceResponse> attendances;
+}

--- a/src/main/java/com/prography/backend/domain/attendance/dto/response/AttendanceResponse.java
+++ b/src/main/java/com/prography/backend/domain/attendance/dto/response/AttendanceResponse.java
@@ -1,0 +1,33 @@
+package com.prography.backend.domain.attendance.dto.response;
+
+import com.prography.backend.domain.attendance.entity.AttendanceStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * packageName    : com.prography.backend.domain.attendance.dto.response<br>
+ * fileName       : AttendanceResponse.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 출결 응답 DTO 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Getter
+@Builder
+public class AttendanceResponse {
+    private Long id;
+    private Long sessionId;
+    private Long memberId;
+    private AttendanceStatus status;
+    private Integer lateMinutes;
+    private Long penaltyAmount;
+    private String reason;
+    private LocalDateTime checkedInAt;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/prography/backend/domain/attendance/entity/AttendanceEntity.java
+++ b/src/main/java/com/prography/backend/domain/attendance/entity/AttendanceEntity.java
@@ -1,0 +1,80 @@
+package com.prography.backend.domain.attendance.entity;
+
+import com.prography.backend.domain.member.entity.MemberEntity;
+import com.prography.backend.domain.session.entity.SessionEntity;
+import com.prography.backend.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * packageName    : com.prography.backend.domain.attendance.entity<br>
+ * fileName       : AttendanceEntity.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 출결 엔티티 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Entity
+@Getter
+@Builder
+@Table(
+        name = "tb_attendance",
+        uniqueConstraints = @UniqueConstraint(name = "uq_attendance_session_member", columnNames = {"session_id", "member_id"})
+)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AttendanceEntity extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "session_id", nullable = false)
+    private SessionEntity session;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false)
+    private MemberEntity member;
+
+    @Column(name = "qrcode_id")
+    private Long qrCodeId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private AttendanceStatus status;
+
+    @Column(name = "late_minutes")
+    private Integer lateMinutes;
+
+    @Column(name = "penalty_amount", nullable = false)
+    private Long penaltyAmount;
+
+    @Column
+    private String reason;
+
+    @Column(name = "checked_in_at")
+    private LocalDateTime checkedInAt;
+
+    public void updateByAdmin(AttendanceStatus status, Integer lateMinutes, Long penaltyAmount, String reason) {
+        this.status = status;
+        this.lateMinutes = lateMinutes;
+        this.penaltyAmount = penaltyAmount;
+        if (reason != null) {
+            this.reason = reason;
+        }
+    }
+}

--- a/src/main/java/com/prography/backend/domain/attendance/entity/AttendanceStatus.java
+++ b/src/main/java/com/prography/backend/domain/attendance/entity/AttendanceStatus.java
@@ -1,0 +1,19 @@
+package com.prography.backend.domain.attendance.entity;
+
+/**
+ * packageName    : com.prography.backend.domain.attendance.entity<br>
+ * fileName       : AttendanceStatus.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 출결 상태 enum 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+public enum AttendanceStatus {
+    PRESENT,
+    ABSENT,
+    LATE,
+    EXCUSED
+}

--- a/src/main/java/com/prography/backend/domain/attendance/mapper/AttendanceMapper.java
+++ b/src/main/java/com/prography/backend/domain/attendance/mapper/AttendanceMapper.java
@@ -1,0 +1,39 @@
+package com.prography.backend.domain.attendance.mapper;
+
+import com.prography.backend.domain.attendance.dto.response.AttendanceResponse;
+import com.prography.backend.domain.attendance.entity.AttendanceEntity;
+import org.springframework.stereotype.Component;
+
+/**
+ * packageName    : com.prography.backend.domain.attendance.mapper<br>
+ * fileName       : AttendanceMapper.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 출결 응답 매핑을 담당하는 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Component
+public class AttendanceMapper {
+
+    public AttendanceResponse toResponse(AttendanceEntity attendance) {
+        if (attendance == null) {
+            return null;
+        }
+
+        return AttendanceResponse.builder()
+                .id(attendance.getId())
+                .sessionId(attendance.getSession().getId())
+                .memberId(attendance.getMember().getId())
+                .status(attendance.getStatus())
+                .lateMinutes(attendance.getLateMinutes())
+                .penaltyAmount(attendance.getPenaltyAmount())
+                .reason(attendance.getReason())
+                .checkedInAt(attendance.getCheckedInAt())
+                .createdAt(attendance.getCreatedAt())
+                .updatedAt(attendance.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/prography/backend/domain/attendance/repository/AttendanceRepository.java
+++ b/src/main/java/com/prography/backend/domain/attendance/repository/AttendanceRepository.java
@@ -1,0 +1,28 @@
+package com.prography.backend.domain.attendance.repository;
+
+import com.prography.backend.domain.attendance.entity.AttendanceEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * packageName    : com.prography.backend.domain.attendance.repository<br>
+ * fileName       : AttendanceRepository.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 출결 레포지토리 인터페이스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+public interface AttendanceRepository extends JpaRepository<AttendanceEntity, Long> {
+    boolean existsBySessionIdAndMemberId(Long sessionId, Long memberId);
+
+    List<AttendanceEntity> findBySessionIdOrderByCreatedAtAsc(Long sessionId);
+
+    List<AttendanceEntity> findByMemberIdOrderByCreatedAtAsc(Long memberId);
+
+    List<AttendanceEntity> findByMemberIdIn(Collection<Long> memberIds);
+}

--- a/src/main/java/com/prography/backend/domain/attendance/service/AdminAttendanceFacadeService.java
+++ b/src/main/java/com/prography/backend/domain/attendance/service/AdminAttendanceFacadeService.java
@@ -1,0 +1,267 @@
+package com.prography.backend.domain.attendance.service;
+
+import com.prography.backend.domain.attendance.dto.request.AdminAttendanceRegisterRequest;
+import com.prography.backend.domain.attendance.dto.request.AdminAttendanceUpdateRequest;
+import com.prography.backend.domain.attendance.dto.response.AdminMemberAttendanceDetailResponse;
+import com.prography.backend.domain.attendance.dto.response.AdminSessionAttendanceSummaryResponse;
+import com.prography.backend.domain.attendance.dto.response.AdminSessionAttendancesResponse;
+import com.prography.backend.domain.attendance.dto.response.AttendanceResponse;
+import com.prography.backend.domain.attendance.entity.AttendanceEntity;
+import com.prography.backend.domain.attendance.entity.AttendanceStatus;
+import com.prography.backend.domain.attendance.mapper.AttendanceMapper;
+import com.prography.backend.domain.cohort.entity.CohortEntity;
+import com.prography.backend.domain.cohort.service.CohortService;
+import com.prography.backend.domain.cohortmember.entity.CohortMemberEntity;
+import com.prography.backend.domain.cohortmember.service.CohortMemberService;
+import com.prography.backend.domain.deposit.service.DepositHistoryService;
+import com.prography.backend.domain.member.entity.MemberEntity;
+import com.prography.backend.domain.member.service.MemberService;
+import com.prography.backend.domain.part.entity.PartEntity;
+import com.prography.backend.domain.session.entity.SessionEntity;
+import com.prography.backend.domain.session.service.SessionService;
+import com.prography.backend.domain.team.entity.TeamEntity;
+import com.prography.backend.global.common.PolicyConstants;
+import com.prography.backend.global.common.StatusCode;
+import com.prography.backend.global.error.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * packageName    : com.prography.backend.domain.attendance.service<br>
+ * fileName       : AdminAttendanceFacadeService.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 관리자 출결 API를 위한 파사드 서비스 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AdminAttendanceFacadeService {
+
+    private final AttendanceService attendanceService;
+    private final AttendanceMapper attendanceMapper;
+    private final SessionService sessionService;
+    private final MemberService memberService;
+    private final CohortService cohortService;
+    private final CohortMemberService cohortMemberService;
+    private final DepositHistoryService depositHistoryService;
+
+    public AttendanceResponse registerAttendance(AdminAttendanceRegisterRequest request) {
+        SessionEntity session = sessionService.getById(request.getSessionId());
+        MemberEntity member = memberService.getById(request.getMemberId());
+
+        if (attendanceService.existsBySessionAndMember(session.getId(), member.getId())) {
+            throw new CustomException(StatusCode.ATTENDANCE_ALREADY_CHECKED);
+        }
+
+        CohortMemberEntity cohortMember = getCurrentCohortMember(member.getId());
+        AttendanceStatus status = request.getStatus();
+        Integer lateMinutes = normalizeLateMinutes(status, request.getLateMinutes());
+
+        if (status == AttendanceStatus.EXCUSED) {
+            validateExcuseLimit(cohortMember.getExcuseCount());
+            cohortMember.updateExcuseCount(cohortMember.getExcuseCount() + 1);
+        }
+
+        long penaltyAmount = calculatePenalty(status, lateMinutes);
+        AttendanceEntity attendance = attendanceService.create(
+                session,
+                member,
+                status,
+                lateMinutes,
+                penaltyAmount,
+                request.getReason(),
+                null
+        );
+
+        if (penaltyAmount > 0) {
+            applyPenalty(cohortMember, penaltyAmount, attendance.getId(), "출결 등록 - " + status + " 패널티 " + penaltyAmount + "원");
+        }
+
+        return attendanceMapper.toResponse(attendance);
+    }
+
+    public AttendanceResponse updateAttendance(Long attendanceId, AdminAttendanceUpdateRequest request) {
+        AttendanceEntity attendance = attendanceService.getById(attendanceId);
+        CohortMemberEntity cohortMember = getCurrentCohortMember(attendance.getMember().getId());
+
+        AttendanceStatus oldStatus = attendance.getStatus();
+        AttendanceStatus newStatus = request.getStatus();
+        Integer lateMinutes = normalizeLateMinutes(newStatus, request.getLateMinutes());
+
+        long oldPenalty = attendance.getPenaltyAmount();
+        long newPenalty = calculatePenalty(newStatus, lateMinutes);
+        long diff = newPenalty - oldPenalty;
+
+        adjustExcuseCount(cohortMember, oldStatus, newStatus);
+        applyDepositDiff(cohortMember, diff, attendance.getId(), newStatus);
+
+        attendance.updateByAdmin(newStatus, lateMinutes, newPenalty, request.getReason());
+        return attendanceMapper.toResponse(attendance);
+    }
+
+    @Transactional(readOnly = true)
+    public List<AdminSessionAttendanceSummaryResponse> getSessionSummary(Long sessionId) {
+        sessionService.getById(sessionId);
+
+        List<CohortMemberEntity> cohortMembers = cohortMemberService.getByGeneration(PolicyConstants.CURRENT_GENERATION);
+
+        List<Long> memberIds = cohortMembers.stream()
+                .map(cohortMember -> cohortMember.getMember().getId())
+                .toList();
+
+        Map<Long, List<AttendanceEntity>> attendanceMap = attendanceService.getByMemberIds(memberIds).stream()
+                .collect(Collectors.groupingBy(attendance -> attendance.getMember().getId()));
+
+        List<AdminSessionAttendanceSummaryResponse> results = new ArrayList<>();
+        for (CohortMemberEntity cohortMember : cohortMembers) {
+            Long memberId = cohortMember.getMember().getId();
+            List<AttendanceEntity> attendances = attendanceMap.getOrDefault(memberId, List.of());
+
+            int present = countStatus(attendances, AttendanceStatus.PRESENT);
+            int absent = countStatus(attendances, AttendanceStatus.ABSENT);
+            int late = countStatus(attendances, AttendanceStatus.LATE);
+            int excused = countStatus(attendances, AttendanceStatus.EXCUSED);
+            long totalPenalty = attendances.stream()
+                    .mapToLong(AttendanceEntity::getPenaltyAmount)
+                    .sum();
+
+            results.add(AdminSessionAttendanceSummaryResponse.builder()
+                    .memberId(memberId)
+                    .memberName(cohortMember.getMember().getName())
+                    .present(present)
+                    .absent(absent)
+                    .late(late)
+                    .excused(excused)
+                    .totalPenalty(totalPenalty)
+                    .deposit(cohortMember.getDeposit())
+                    .build());
+        }
+
+        return results;
+    }
+
+    @Transactional(readOnly = true)
+    public AdminMemberAttendanceDetailResponse getMemberAttendanceDetail(Long memberId) {
+        MemberEntity member = memberService.getById(memberId);
+        List<AttendanceResponse> attendances = attendanceService.getByMemberId(memberId).stream()
+                .map(attendanceMapper::toResponse)
+                .toList();
+
+        CohortEntity cohort = cohortService.getByGeneration(PolicyConstants.CURRENT_GENERATION);
+        Optional<CohortMemberEntity> cohortMember = cohortMemberService.findByMemberAndCohort(memberId, cohort.getId());
+
+        PartEntity part = cohortMember.map(CohortMemberEntity::getPart).orElse(null);
+        TeamEntity team = cohortMember.map(CohortMemberEntity::getTeam).orElse(null);
+
+        return AdminMemberAttendanceDetailResponse.builder()
+                .memberId(member.getId())
+                .memberName(member.getName())
+                .generation(cohortMember.map(cm -> cm.getCohort().getGeneration()).orElse(null))
+                .partName(part == null ? null : part.getName())
+                .teamName(team == null ? null : team.getName())
+                .deposit(cohortMember.map(CohortMemberEntity::getDeposit).orElse(null))
+                .excuseCount(cohortMember.map(CohortMemberEntity::getExcuseCount).orElse(null))
+                .attendances(attendances)
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public AdminSessionAttendancesResponse getSessionAttendances(Long sessionId) {
+        SessionEntity session = sessionService.getById(sessionId);
+        List<AttendanceResponse> attendances = attendanceService.getBySessionId(sessionId).stream()
+                .map(attendanceMapper::toResponse)
+                .toList();
+
+        return AdminSessionAttendancesResponse.builder()
+                .sessionId(session.getId())
+                .sessionTitle(session.getTitle())
+                .attendances(attendances)
+                .build();
+    }
+
+    private CohortMemberEntity getCurrentCohortMember(Long memberId) {
+        CohortEntity cohort = cohortService.getByGeneration(PolicyConstants.CURRENT_GENERATION);
+        return cohortMemberService.findByMemberAndCohort(memberId, cohort.getId())
+                .orElseThrow(() -> new CustomException(StatusCode.COHORT_MEMBER_NOT_FOUND));
+    }
+
+    private Integer normalizeLateMinutes(AttendanceStatus status, Integer lateMinutes) {
+        if (status == AttendanceStatus.LATE) {
+            if (lateMinutes == null) {
+                throw new CustomException(StatusCode.INVALID_INPUT);
+            }
+            if (lateMinutes < 0) {
+                throw new CustomException(StatusCode.INVALID_INPUT);
+            }
+            return lateMinutes;
+        }
+        return null;
+    }
+
+    private long calculatePenalty(AttendanceStatus status, Integer lateMinutes) {
+        return switch (status) {
+            case PRESENT, EXCUSED -> 0;
+            case ABSENT -> PolicyConstants.PENALTY_ABSENT;
+            case LATE -> Math.min((long) lateMinutes * PolicyConstants.PENALTY_LATE_PER_MINUTE, PolicyConstants.PENALTY_MAX);
+        };
+    }
+
+    private void validateExcuseLimit(int excuseCount) {
+        if (excuseCount >= PolicyConstants.EXCUSE_LIMIT) {
+            throw new CustomException(StatusCode.EXCUSE_LIMIT_EXCEEDED);
+        }
+    }
+
+    private void adjustExcuseCount(CohortMemberEntity cohortMember, AttendanceStatus oldStatus, AttendanceStatus newStatus) {
+        if (oldStatus != AttendanceStatus.EXCUSED && newStatus == AttendanceStatus.EXCUSED) {
+            validateExcuseLimit(cohortMember.getExcuseCount());
+            cohortMember.updateExcuseCount(cohortMember.getExcuseCount() + 1);
+        } else if (oldStatus == AttendanceStatus.EXCUSED && newStatus != AttendanceStatus.EXCUSED) {
+            cohortMember.updateExcuseCount(Math.max(0, cohortMember.getExcuseCount() - 1));
+        }
+    }
+
+    private void applyDepositDiff(CohortMemberEntity cohortMember, long diff, Long attendanceId, AttendanceStatus status) {
+        if (diff == 0) {
+            return;
+        }
+
+        if (diff > 0) {
+            applyPenalty(cohortMember, diff, attendanceId, "출결 수정 - " + status + " 패널티 " + diff + "원");
+            return;
+        }
+
+        long refundAmount = Math.abs(diff);
+        long newDeposit = cohortMember.getDeposit() + refundAmount;
+        cohortMember.updateDeposit(newDeposit);
+        depositHistoryService.createRefund(cohortMember, refundAmount, attendanceId, "출결 수정 - 환급 " + refundAmount + "원");
+    }
+
+    private void applyPenalty(CohortMemberEntity cohortMember, long penaltyAmount, Long attendanceId, String description) {
+        if (cohortMember.getDeposit() < penaltyAmount) {
+            throw new CustomException(StatusCode.DEPOSIT_INSUFFICIENT);
+        }
+
+        long newDeposit = cohortMember.getDeposit() - penaltyAmount;
+        cohortMember.updateDeposit(newDeposit);
+        depositHistoryService.createPenalty(cohortMember, penaltyAmount, attendanceId, description);
+    }
+
+    private int countStatus(List<AttendanceEntity> attendances, AttendanceStatus status) {
+        return (int) attendances.stream()
+                .filter(attendance -> attendance.getStatus() == status)
+                .count();
+    }
+}

--- a/src/main/java/com/prography/backend/domain/attendance/service/AttendanceService.java
+++ b/src/main/java/com/prography/backend/domain/attendance/service/AttendanceService.java
@@ -1,0 +1,80 @@
+package com.prography.backend.domain.attendance.service;
+
+import com.prography.backend.domain.attendance.entity.AttendanceEntity;
+import com.prography.backend.domain.attendance.entity.AttendanceStatus;
+import com.prography.backend.domain.attendance.repository.AttendanceRepository;
+import com.prography.backend.domain.member.entity.MemberEntity;
+import com.prography.backend.domain.session.entity.SessionEntity;
+import com.prography.backend.global.common.StatusCode;
+import com.prography.backend.global.error.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * packageName    : com.prography.backend.domain.attendance.service<br>
+ * fileName       : AttendanceService.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 출결 관련 비즈니스 로직을 처리하는 서비스 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AttendanceService {
+
+    private final AttendanceRepository attendanceRepository;
+
+    public AttendanceEntity create(SessionEntity session, MemberEntity member, AttendanceStatus status,
+                                   Integer lateMinutes, Long penaltyAmount, String reason, LocalDateTime checkedInAt) {
+        AttendanceEntity attendance = AttendanceEntity.builder()
+                .session(session)
+                .member(member)
+                .qrCodeId(null)
+                .status(status)
+                .lateMinutes(lateMinutes)
+                .penaltyAmount(penaltyAmount)
+                .reason(reason)
+                .checkedInAt(checkedInAt)
+                .build();
+
+        return attendanceRepository.save(attendance);
+    }
+
+    @Transactional(readOnly = true)
+    public AttendanceEntity getById(Long id) {
+        return attendanceRepository.findById(id)
+                .orElseThrow(() -> new CustomException(StatusCode.ATTENDANCE_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public boolean existsBySessionAndMember(Long sessionId, Long memberId) {
+        return attendanceRepository.existsBySessionIdAndMemberId(sessionId, memberId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<AttendanceEntity> getBySessionId(Long sessionId) {
+        return attendanceRepository.findBySessionIdOrderByCreatedAtAsc(sessionId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<AttendanceEntity> getByMemberId(Long memberId) {
+        return attendanceRepository.findByMemberIdOrderByCreatedAtAsc(memberId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<AttendanceEntity> getByMemberIds(Collection<Long> memberIds) {
+        if (memberIds == null || memberIds.isEmpty()) {
+            return List.of();
+        }
+        return attendanceRepository.findByMemberIdIn(memberIds);
+    }
+}

--- a/src/main/java/com/prography/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/prography/backend/domain/auth/controller/AuthController.java
@@ -1,10 +1,8 @@
 package com.prography.backend.domain.auth.controller;
 
 import com.prography.backend.domain.auth.dto.request.LoginRequest;
-import com.prography.backend.domain.auth.service.AuthService;
+import com.prography.backend.domain.auth.service.AuthFacadeService;
 import com.prography.backend.domain.member.dto.response.MemberResponse;
-import com.prography.backend.domain.member.entity.MemberEntity;
-import com.prography.backend.domain.member.mapper.MemberMapper;
 import com.prography.backend.global.response.ApiResponse;
 import com.prography.backend.global.util.ResponseUtility;
 import jakarta.validation.Valid;
@@ -31,12 +29,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/auth")
 public class AuthController {
 
-    private final AuthService authService;
-    private final MemberMapper memberMapper;
+    private final AuthFacadeService authFacadeService;
 
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<MemberResponse>> login(@RequestBody @Valid LoginRequest request) {
-        MemberEntity member = authService.login(request);
-        return ResponseUtility.success(memberMapper.toMemberResponse(member));
+        return ResponseUtility.success(authFacadeService.login(request));
     }
 }

--- a/src/main/java/com/prography/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/prography/backend/domain/auth/controller/AuthController.java
@@ -23,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
  * DATE              AUTHOR             NOTE<br>
  * -----------------------------------------------------------<br>
  * 2026-02-24         cod0216             최초생성<br>
+ * 2026-02-24         cod0216             로그인 응답 매핑 파사드 위임<br>
  */
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/prography/backend/domain/auth/service/AuthFacadeService.java
+++ b/src/main/java/com/prography/backend/domain/auth/service/AuthFacadeService.java
@@ -1,0 +1,34 @@
+package com.prography.backend.domain.auth.service;
+
+import com.prography.backend.domain.auth.dto.request.LoginRequest;
+import com.prography.backend.domain.member.dto.response.MemberResponse;
+import com.prography.backend.domain.member.entity.MemberEntity;
+import com.prography.backend.domain.member.mapper.MemberMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * packageName    : com.prography.backend.domain.auth.service<br>
+ * fileName       : AuthFacadeService.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-25<br>
+ * description    : 인증 응답 매핑을 처리하는 파사드 서비스 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-25         cod0216             최초생성<br>
+ */
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AuthFacadeService {
+
+    private final AuthService authService;
+    private final MemberMapper memberMapper;
+
+    public MemberResponse login(LoginRequest request) {
+        MemberEntity member = authService.login(request);
+        return memberMapper.toMemberResponse(member);
+    }
+}

--- a/src/main/java/com/prography/backend/domain/cohort/repository/CohortRepository.java
+++ b/src/main/java/com/prography/backend/domain/cohort/repository/CohortRepository.java
@@ -3,6 +3,8 @@ package com.prography.backend.domain.cohort.repository;
 import com.prography.backend.domain.cohort.entity.CohortEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 /**
  * packageName    : com.prography.backend.domain.cohort.repository<br>
  * fileName       : CohortRepository.java<br>
@@ -15,4 +17,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
  * 2026-02-24         cod0216             최초생성<br>
  */
 public interface CohortRepository extends JpaRepository<CohortEntity, Long> {
+    Optional<CohortEntity> findByGeneration(Integer generation);
 }

--- a/src/main/java/com/prography/backend/domain/cohort/service/CohortService.java
+++ b/src/main/java/com/prography/backend/domain/cohort/service/CohortService.java
@@ -37,4 +37,9 @@ public class CohortService {
         return cohortRepository.findById(id)
                 .orElseThrow(() -> new CustomException(StatusCode.COHORT_NOT_FOUND));
     }
+
+    public CohortEntity getByGeneration(Integer generation) {
+        return cohortRepository.findByGeneration(generation)
+                .orElseThrow(() -> new CustomException(StatusCode.COHORT_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/prography/backend/domain/cohortmember/entity/CohortMemberEntity.java
+++ b/src/main/java/com/prography/backend/domain/cohortmember/entity/CohortMemberEntity.java
@@ -65,4 +65,12 @@ public class CohortMemberEntity extends BaseEntity {
     public void updateExcuseCount(Integer excuseCount) {
         this.excuseCount = excuseCount;
     }
+
+    public void updatePart(PartEntity part) {
+        this.part = part;
+    }
+
+    public void updateTeam(TeamEntity team) {
+        this.team = team;
+    }
 }

--- a/src/main/java/com/prography/backend/domain/cohortmember/repository/CohortMemberRepository.java
+++ b/src/main/java/com/prography/backend/domain/cohortmember/repository/CohortMemberRepository.java
@@ -3,6 +3,8 @@ package com.prography.backend.domain.cohortmember.repository;
 import com.prography.backend.domain.cohortmember.entity.CohortMemberEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 /**
  * packageName    : com.prography.backend.domain.cohortmember.repository<br>
  * fileName       : CohortMemberRepository.java<br>
@@ -15,4 +17,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
  * 2026-02-24         cod0216             최초생성<br>
  */
 public interface CohortMemberRepository extends JpaRepository<CohortMemberEntity, Long> {
+    Optional<CohortMemberEntity> findFirstByMemberIdOrderByIdDesc(Long memberId);
+    Optional<CohortMemberEntity> findByMemberIdAndCohortId(Long memberId, Long cohortId);
 }

--- a/src/main/java/com/prography/backend/domain/cohortmember/repository/CohortMemberRepository.java
+++ b/src/main/java/com/prography/backend/domain/cohortmember/repository/CohortMemberRepository.java
@@ -3,6 +3,7 @@ package com.prography.backend.domain.cohortmember.repository;
 import com.prography.backend.domain.cohortmember.entity.CohortMemberEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -19,4 +20,5 @@ import java.util.Optional;
 public interface CohortMemberRepository extends JpaRepository<CohortMemberEntity, Long> {
     Optional<CohortMemberEntity> findFirstByMemberIdOrderByIdDesc(Long memberId);
     Optional<CohortMemberEntity> findByMemberIdAndCohortId(Long memberId, Long cohortId);
+    List<CohortMemberEntity> findByCohortGenerationOrderByMemberIdAsc(Integer generation);
 }

--- a/src/main/java/com/prography/backend/domain/cohortmember/repository/CohortMemberRepository.java
+++ b/src/main/java/com/prography/backend/domain/cohortmember/repository/CohortMemberRepository.java
@@ -16,6 +16,7 @@ import java.util.Optional;
  * DATE              AUTHOR             NOTE<br>
  * -----------------------------------------------------------<br>
  * 2026-02-24         cod0216             최초생성<br>
+ * 2026-02-24         cod0216             기수별 조회 메서드 추가<br>
  */
 public interface CohortMemberRepository extends JpaRepository<CohortMemberEntity, Long> {
     Optional<CohortMemberEntity> findFirstByMemberIdOrderByIdDesc(Long memberId);

--- a/src/main/java/com/prography/backend/domain/cohortmember/service/CohortMemberService.java
+++ b/src/main/java/com/prography/backend/domain/cohortmember/service/CohortMemberService.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -53,6 +54,11 @@ public class CohortMemberService {
     @Transactional(readOnly = true)
     public Optional<CohortMemberEntity> findByMemberAndCohort(Long memberId, Long cohortId) {
         return cohortMemberRepository.findByMemberIdAndCohortId(memberId, cohortId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<CohortMemberEntity> getByGeneration(Integer generation) {
+        return cohortMemberRepository.findByCohortGenerationOrderByMemberIdAsc(generation);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/prography/backend/domain/cohortmember/service/CohortMemberService.java
+++ b/src/main/java/com/prography/backend/domain/cohortmember/service/CohortMemberService.java
@@ -12,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 /**
  * packageName    : com.prography.backend.domain.cohortmember.service<br>
  * fileName       : CohortMemberService.java<br>
@@ -41,6 +43,16 @@ public class CohortMemberService {
                 .build();
 
         return cohortMemberRepository.save(cohortMember);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<CohortMemberEntity> findLatestByMemberId(Long memberId) {
+        return cohortMemberRepository.findFirstByMemberIdOrderByIdDesc(memberId);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<CohortMemberEntity> findByMemberAndCohort(Long memberId, Long cohortId) {
+        return cohortMemberRepository.findByMemberIdAndCohortId(memberId, cohortId);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/prography/backend/domain/cohortmember/service/CohortMemberService.java
+++ b/src/main/java/com/prography/backend/domain/cohortmember/service/CohortMemberService.java
@@ -25,6 +25,7 @@ import java.util.Optional;
  * DATE              AUTHOR             NOTE<br>
  * -----------------------------------------------------------<br>
  * 2026-02-24         cod0216             최초생성<br>
+ * 2026-02-24         cod0216             기수별 조회 기능 추가<br>
  */
 @Service
 @Transactional

--- a/src/main/java/com/prography/backend/domain/deposit/controller/AdminDepositController.java
+++ b/src/main/java/com/prography/backend/domain/deposit/controller/AdminDepositController.java
@@ -1,0 +1,38 @@
+package com.prography.backend.domain.deposit.controller;
+
+import com.prography.backend.domain.deposit.dto.response.DepositHistoryResponse;
+import com.prography.backend.domain.deposit.service.DepositHistoryAdminFacadeService;
+import com.prography.backend.global.response.ApiResponse;
+import com.prography.backend.global.util.ResponseUtility;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * packageName    : com.prography.backend.domain.deposit.controller<br>
+ * fileName       : AdminDepositController.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 관리자 보증금 API를 처리하는 컨트롤러 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/cohort-members")
+public class AdminDepositController {
+
+    private final DepositHistoryAdminFacadeService depositHistoryAdminFacadeService;
+
+    @GetMapping("/{cohortMemberId}/deposits")
+    public ResponseEntity<ApiResponse<List<DepositHistoryResponse>>> getDepositHistory(@PathVariable Long cohortMemberId) {
+        return ResponseUtility.success(depositHistoryAdminFacadeService.getDepositHistories(cohortMemberId));
+    }
+}

--- a/src/main/java/com/prography/backend/domain/deposit/dto/response/DepositHistoryResponse.java
+++ b/src/main/java/com/prography/backend/domain/deposit/dto/response/DepositHistoryResponse.java
@@ -1,0 +1,31 @@
+package com.prography.backend.domain.deposit.dto.response;
+
+import com.prography.backend.domain.deposit.entity.DepositType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * packageName    : com.prography.backend.domain.deposit.dto.response<br>
+ * fileName       : DepositHistoryResponse.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 보증금 이력 응답 DTO 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Getter
+@Builder
+public class DepositHistoryResponse {
+    private Long id;
+    private Long cohortMemberId;
+    private DepositType type;
+    private Long amount;
+    private Long balanceAfter;
+    private Long attendanceId;
+    private String description;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/prography/backend/domain/deposit/entity/DepositHistoryEntity.java
+++ b/src/main/java/com/prography/backend/domain/deposit/entity/DepositHistoryEntity.java
@@ -1,0 +1,57 @@
+package com.prography.backend.domain.deposit.entity;
+
+import com.prography.backend.domain.cohortmember.entity.CohortMemberEntity;
+import com.prography.backend.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * packageName    : com.prography.backend.domain.deposit.entity<br>
+ * fileName       : DepositHistoryEntity.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-25<br>
+ * description    : 보증금 이력 엔티티 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-25         cod0216             최초생성<br>
+ */
+@Entity
+@Getter
+@Builder
+@Table(name = "tb_deposit_history")
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DepositHistoryEntity extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "cohort_member_id", nullable = false)
+    private CohortMemberEntity cohortMember;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private DepositType type;
+
+    @Column(nullable = false)
+    private Long amount;
+
+    @Column(name = "balance_after", nullable = false)
+    private Long balanceAfter;
+
+    @Column(name = "attendance_id")
+    private Long attendanceId;
+
+    @Column
+    private String description;
+}

--- a/src/main/java/com/prography/backend/domain/deposit/entity/DepositType.java
+++ b/src/main/java/com/prography/backend/domain/deposit/entity/DepositType.java
@@ -1,0 +1,23 @@
+package com.prography.backend.domain.deposit.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * packageName    : com.prography.backend.domain.deposit.entity<br>
+ * fileName       : DepositType.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-25<br>
+ * description    : 보증금 이력 타입을 정의하는 enum 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-25         cod0216             최초생성<br>
+ */
+@Getter
+@RequiredArgsConstructor
+public enum DepositType {
+    INITIAL,
+    PENALTY,
+    REFUND
+}

--- a/src/main/java/com/prography/backend/domain/deposit/mapper/DepositHistoryMapper.java
+++ b/src/main/java/com/prography/backend/domain/deposit/mapper/DepositHistoryMapper.java
@@ -1,0 +1,37 @@
+package com.prography.backend.domain.deposit.mapper;
+
+import com.prography.backend.domain.deposit.dto.response.DepositHistoryResponse;
+import com.prography.backend.domain.deposit.entity.DepositHistoryEntity;
+import org.springframework.stereotype.Component;
+
+/**
+ * packageName    : com.prography.backend.domain.deposit.mapper<br>
+ * fileName       : DepositHistoryMapper.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 보증금 이력 응답 매핑을 담당하는 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Component
+public class DepositHistoryMapper {
+
+    public DepositHistoryResponse toResponse(DepositHistoryEntity history) {
+        if (history == null) {
+            return null;
+        }
+
+        return DepositHistoryResponse.builder()
+                .id(history.getId())
+                .cohortMemberId(history.getCohortMember().getId())
+                .type(history.getType())
+                .amount(history.getAmount())
+                .balanceAfter(history.getBalanceAfter())
+                .attendanceId(history.getAttendanceId())
+                .description(history.getDescription())
+                .createdAt(history.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/prography/backend/domain/deposit/repository/DepositHistoryRepository.java
+++ b/src/main/java/com/prography/backend/domain/deposit/repository/DepositHistoryRepository.java
@@ -1,0 +1,21 @@
+package com.prography.backend.domain.deposit.repository;
+
+import com.prography.backend.domain.deposit.entity.DepositHistoryEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+/**
+ * packageName    : com.prography.backend.domain.deposit.repository<br>
+ * fileName       : DepositHistoryRepository.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-25<br>
+ * description    : 보증금 이력 레포지토리 인터페이스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-25         cod0216             최초생성<br>
+ */
+public interface DepositHistoryRepository extends JpaRepository<DepositHistoryEntity, Long> {
+    List<DepositHistoryEntity> findByCohortMemberIdOrderByCreatedAtAsc(Long cohortMemberId);
+}

--- a/src/main/java/com/prography/backend/domain/deposit/service/DepositHistoryAdminFacadeService.java
+++ b/src/main/java/com/prography/backend/domain/deposit/service/DepositHistoryAdminFacadeService.java
@@ -1,0 +1,39 @@
+package com.prography.backend.domain.deposit.service;
+
+import com.prography.backend.domain.cohortmember.service.CohortMemberService;
+import com.prography.backend.domain.deposit.dto.response.DepositHistoryResponse;
+import com.prography.backend.domain.deposit.mapper.DepositHistoryMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * packageName    : com.prography.backend.domain.deposit.service<br>
+ * fileName       : DepositHistoryAdminFacadeService.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 관리자 보증금 이력 조회를 처리하는 파사드 서비스 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class DepositHistoryAdminFacadeService {
+
+    private final CohortMemberService cohortMemberService;
+    private final DepositHistoryService depositHistoryService;
+    private final DepositHistoryMapper depositHistoryMapper;
+
+    public List<DepositHistoryResponse> getDepositHistories(Long cohortMemberId) {
+        cohortMemberService.getById(cohortMemberId);
+
+        return depositHistoryService.getByCohortMemberIdOrderByCreatedAtAsc(cohortMemberId).stream()
+                .map(depositHistoryMapper::toResponse)
+                .toList();
+    }
+}

--- a/src/main/java/com/prography/backend/domain/deposit/service/DepositHistoryService.java
+++ b/src/main/java/com/prography/backend/domain/deposit/service/DepositHistoryService.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 /**
  * packageName    : com.prography.backend.domain.deposit.service<br>
  * fileName       : DepositHistoryService.java<br>
@@ -25,6 +27,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class DepositHistoryService {
 
     private final DepositHistoryRepository depositHistoryRepository;
+
+    @Transactional(readOnly = true)
+    public List<DepositHistoryEntity> getByCohortMemberIdOrderByCreatedAtAsc(Long cohortMemberId) {
+        return depositHistoryRepository.findByCohortMemberIdOrderByCreatedAtAsc(cohortMemberId);
+    }
 
     public DepositHistoryEntity createInitial(CohortMemberEntity cohortMember, Long amount, String description) {
         DepositHistoryEntity history = DepositHistoryEntity.builder()

--- a/src/main/java/com/prography/backend/domain/deposit/service/DepositHistoryService.java
+++ b/src/main/java/com/prography/backend/domain/deposit/service/DepositHistoryService.java
@@ -1,0 +1,41 @@
+package com.prography.backend.domain.deposit.service;
+
+import com.prography.backend.domain.cohortmember.entity.CohortMemberEntity;
+import com.prography.backend.domain.deposit.entity.DepositHistoryEntity;
+import com.prography.backend.domain.deposit.entity.DepositType;
+import com.prography.backend.domain.deposit.repository.DepositHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * packageName    : com.prography.backend.domain.deposit.service<br>
+ * fileName       : DepositHistoryService.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-25<br>
+ * description    : 보증금 이력 관련 비즈니스 로직을 처리하는 서비스 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-25         cod0216             최초생성<br>
+ */
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class DepositHistoryService {
+
+    private final DepositHistoryRepository depositHistoryRepository;
+
+    public DepositHistoryEntity createInitial(CohortMemberEntity cohortMember, Long amount, String description) {
+        DepositHistoryEntity history = DepositHistoryEntity.builder()
+                .cohortMember(cohortMember)
+                .type(DepositType.INITIAL)
+                .amount(amount)
+                .balanceAfter(cohortMember.getDeposit())
+                .attendanceId(null)
+                .description(description)
+                .build();
+
+        return depositHistoryRepository.save(history);
+    }
+}

--- a/src/main/java/com/prography/backend/domain/deposit/service/DepositHistoryService.java
+++ b/src/main/java/com/prography/backend/domain/deposit/service/DepositHistoryService.java
@@ -20,6 +20,7 @@ import java.util.List;
  * DATE              AUTHOR             NOTE<br>
  * -----------------------------------------------------------<br>
  * 2026-02-25         cod0216             최초생성<br>
+ * 2026-02-24         cod0216             패널티/환급 이력 생성 추가<br>
  */
 @Service
 @Transactional

--- a/src/main/java/com/prography/backend/domain/deposit/service/DepositHistoryService.java
+++ b/src/main/java/com/prography/backend/domain/deposit/service/DepositHistoryService.java
@@ -45,4 +45,30 @@ public class DepositHistoryService {
 
         return depositHistoryRepository.save(history);
     }
+
+    public DepositHistoryEntity createPenalty(CohortMemberEntity cohortMember, Long penaltyAmount, Long attendanceId, String description) {
+        DepositHistoryEntity history = DepositHistoryEntity.builder()
+                .cohortMember(cohortMember)
+                .type(DepositType.PENALTY)
+                .amount(-penaltyAmount)
+                .balanceAfter(cohortMember.getDeposit())
+                .attendanceId(attendanceId)
+                .description(description)
+                .build();
+
+        return depositHistoryRepository.save(history);
+    }
+
+    public DepositHistoryEntity createRefund(CohortMemberEntity cohortMember, Long refundAmount, Long attendanceId, String description) {
+        DepositHistoryEntity history = DepositHistoryEntity.builder()
+                .cohortMember(cohortMember)
+                .type(DepositType.REFUND)
+                .amount(refundAmount)
+                .balanceAfter(cohortMember.getDeposit())
+                .attendanceId(attendanceId)
+                .description(description)
+                .build();
+
+        return depositHistoryRepository.save(history);
+    }
 }

--- a/src/main/java/com/prography/backend/domain/member/controller/AdminMemberController.java
+++ b/src/main/java/com/prography/backend/domain/member/controller/AdminMemberController.java
@@ -1,0 +1,92 @@
+package com.prography.backend.domain.member.controller;
+
+import com.prography.backend.domain.member.dto.request.AdminMemberCreateRequest;
+import com.prography.backend.domain.member.dto.request.AdminMemberUpdateRequest;
+import com.prography.backend.domain.member.dto.request.MemberDashboardQuery;
+import com.prography.backend.domain.member.dto.response.MemberAdminResponse;
+import com.prography.backend.domain.member.dto.response.MemberDashboardItemResponse;
+import com.prography.backend.domain.member.dto.response.MemberWithdrawResponse;
+import com.prography.backend.domain.member.entity.MemberStatus;
+import com.prography.backend.domain.member.service.MemberAdminFacadeService;
+import com.prography.backend.global.response.ApiResponse;
+import com.prography.backend.global.response.PageResponse;
+import com.prography.backend.global.util.ResponseUtility;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * packageName    : com.prography.backend.domain.member.controller<br>
+ * fileName       : AdminMemberController.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-25<br>
+ * description    : 관리자 회원 API를 처리하는 컨트롤러 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-25         cod0216             최초생성<br>
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/members")
+public class AdminMemberController {
+
+    private final MemberAdminFacadeService memberAdminFacadeService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<MemberAdminResponse>> createMember(@RequestBody @Valid AdminMemberCreateRequest request) {
+        return ResponseUtility.created(memberAdminFacadeService.createMember(request));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<PageResponse<MemberDashboardItemResponse>>> getMembers(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(required = false) String searchType,
+            @RequestParam(required = false) String searchValue,
+            @RequestParam(required = false) Integer generation,
+            @RequestParam(required = false) String partName,
+            @RequestParam(required = false) String teamName,
+            @RequestParam(required = false) MemberStatus status
+    ) {
+        MemberDashboardQuery query = MemberDashboardQuery.builder()
+                .page(page)
+                .size(size)
+                .searchType(searchType)
+                .searchValue(searchValue)
+                .generation(generation)
+                .partName(partName)
+                .teamName(teamName)
+                .status(status)
+                .build();
+
+        return ResponseUtility.success(memberAdminFacadeService.getMemberDashboard(query));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<MemberAdminResponse>> getMemberDetail(@PathVariable Long id) {
+        return ResponseUtility.success(memberAdminFacadeService.getMemberDetail(id));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiResponse<MemberAdminResponse>> updateMember(
+            @PathVariable Long id,
+            @RequestBody AdminMemberUpdateRequest request
+    ) {
+        return ResponseUtility.success(memberAdminFacadeService.updateMember(id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<MemberWithdrawResponse>> deleteMember(@PathVariable Long id) {
+        return ResponseUtility.success(memberAdminFacadeService.withdrawMember(id));
+    }
+}

--- a/src/main/java/com/prography/backend/domain/member/controller/MemberController.java
+++ b/src/main/java/com/prography/backend/domain/member/controller/MemberController.java
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
  * DATE              AUTHOR             NOTE<br>
  * -----------------------------------------------------------<br>
  * 2026-02-24         cod0216             최초생성<br>
+ * 2026-02-24         cod0216             회원 조회 응답 매핑 파사드 위임<br>
  */
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/prography/backend/domain/member/controller/MemberController.java
+++ b/src/main/java/com/prography/backend/domain/member/controller/MemberController.java
@@ -1,9 +1,7 @@
 package com.prography.backend.domain.member.controller;
 
 import com.prography.backend.domain.member.dto.response.MemberResponse;
-import com.prography.backend.domain.member.entity.MemberEntity;
-import com.prography.backend.domain.member.mapper.MemberMapper;
-import com.prography.backend.domain.member.service.MemberService;
+import com.prography.backend.domain.member.service.MemberFacadeService;
 import com.prography.backend.global.response.ApiResponse;
 import com.prography.backend.global.util.ResponseUtility;
 import lombok.RequiredArgsConstructor;
@@ -29,12 +27,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/members")
 public class MemberController {
 
-    private final MemberService memberService;
-    private final MemberMapper memberMapper;
+    private final MemberFacadeService memberFacadeService;
 
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponse<MemberResponse>> getMember(@PathVariable Long id) {
-        MemberEntity member = memberService.getById(id);
-        return ResponseUtility.success(memberMapper.toMemberResponse(member));
+        return ResponseUtility.success(memberFacadeService.getMember(id));
     }
 }

--- a/src/main/java/com/prography/backend/domain/member/dto/request/AdminMemberCreateRequest.java
+++ b/src/main/java/com/prography/backend/domain/member/dto/request/AdminMemberCreateRequest.java
@@ -1,0 +1,38 @@
+package com.prography.backend.domain.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+/**
+ * packageName    : com.prography.backend.domain.member.dto.request<br>
+ * fileName       : AdminMemberCreateRequest.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-25<br>
+ * description    : 관리자 회원 생성 요청 DTO 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-25         cod0216             최초생성<br>
+ */
+@Getter
+public class AdminMemberCreateRequest {
+
+    @NotBlank(message = "loginId는 필수입니다.")
+    private String loginId;
+
+    @NotBlank(message = "password는 필수입니다.")
+    private String password;
+
+    @NotBlank(message = "name은 필수입니다.")
+    private String name;
+
+    @NotBlank(message = "phone은 필수입니다.")
+    private String phone;
+
+    @NotNull(message = "cohortId는 필수입니다.")
+    private Long cohortId;
+
+    private Long partId;
+    private Long teamId;
+}

--- a/src/main/java/com/prography/backend/domain/member/dto/request/AdminMemberUpdateRequest.java
+++ b/src/main/java/com/prography/backend/domain/member/dto/request/AdminMemberUpdateRequest.java
@@ -1,0 +1,23 @@
+package com.prography.backend.domain.member.dto.request;
+
+import lombok.Getter;
+
+/**
+ * packageName    : com.prography.backend.domain.member.dto.request<br>
+ * fileName       : AdminMemberUpdateRequest.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-25<br>
+ * description    : 관리자 회원 수정 요청 DTO 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-25         cod0216             최초생성<br>
+ */
+@Getter
+public class AdminMemberUpdateRequest {
+    private String name;
+    private String phone;
+    private Long cohortId;
+    private Long partId;
+    private Long teamId;
+}

--- a/src/main/java/com/prography/backend/domain/member/dto/request/MemberDashboardQuery.java
+++ b/src/main/java/com/prography/backend/domain/member/dto/request/MemberDashboardQuery.java
@@ -1,0 +1,29 @@
+package com.prography.backend.domain.member.dto.request;
+
+import com.prography.backend.domain.member.entity.MemberStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * packageName    : com.prography.backend.domain.member.dto.request<br>
+ * fileName       : MemberDashboardQuery.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-25<br>
+ * description    : 회원 대시보드 조회 조건 DTO 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-25         cod0216             최초생성<br>
+ */
+@Getter
+@Builder
+public class MemberDashboardQuery {
+    private int page;
+    private int size;
+    private String searchType;
+    private String searchValue;
+    private Integer generation;
+    private String partName;
+    private String teamName;
+    private MemberStatus status;
+}

--- a/src/main/java/com/prography/backend/domain/member/dto/response/MemberAdminResponse.java
+++ b/src/main/java/com/prography/backend/domain/member/dto/response/MemberAdminResponse.java
@@ -1,0 +1,35 @@
+package com.prography.backend.domain.member.dto.response;
+
+import com.prography.backend.domain.member.entity.MemberRole;
+import com.prography.backend.domain.member.entity.MemberStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * packageName    : com.prography.backend.domain.member.dto.response<br>
+ * fileName       : MemberAdminResponse.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-25<br>
+ * description    : 관리자 회원 응답 DTO 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-25         cod0216             최초생성<br>
+ */
+@Getter
+@Builder
+public class MemberAdminResponse {
+    private Long id;
+    private String loginId;
+    private String name;
+    private String phone;
+    private MemberStatus status;
+    private MemberRole role;
+    private Integer generation;
+    private String partName;
+    private String teamName;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/prography/backend/domain/member/dto/response/MemberDashboardItemResponse.java
+++ b/src/main/java/com/prography/backend/domain/member/dto/response/MemberDashboardItemResponse.java
@@ -1,0 +1,36 @@
+package com.prography.backend.domain.member.dto.response;
+
+import com.prography.backend.domain.member.entity.MemberRole;
+import com.prography.backend.domain.member.entity.MemberStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * packageName    : com.prography.backend.domain.member.dto.response<br>
+ * fileName       : MemberDashboardItemResponse.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-25<br>
+ * description    : 회원 대시보드 항목 DTO 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-25         cod0216             최초생성<br>
+ */
+@Getter
+@Builder
+public class MemberDashboardItemResponse {
+    private Long id;
+    private String loginId;
+    private String name;
+    private String phone;
+    private MemberStatus status;
+    private MemberRole role;
+    private Integer generation;
+    private String partName;
+    private String teamName;
+    private Long deposit;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/prography/backend/domain/member/dto/response/MemberWithdrawResponse.java
+++ b/src/main/java/com/prography/backend/domain/member/dto/response/MemberWithdrawResponse.java
@@ -1,0 +1,28 @@
+package com.prography.backend.domain.member.dto.response;
+
+import com.prography.backend.domain.member.entity.MemberStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * packageName    : com.prography.backend.domain.member.dto.response<br>
+ * fileName       : MemberWithdrawResponse.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-25<br>
+ * description    : 회원 탈퇴 응답 DTO 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-25         cod0216             최초생성<br>
+ */
+@Getter
+@Builder
+public class MemberWithdrawResponse {
+    private Long id;
+    private String loginId;
+    private String name;
+    private MemberStatus status;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/prography/backend/domain/member/mapper/MemberAdminMapper.java
+++ b/src/main/java/com/prography/backend/domain/member/mapper/MemberAdminMapper.java
@@ -1,0 +1,103 @@
+package com.prography.backend.domain.member.mapper;
+
+import com.prography.backend.domain.cohortmember.entity.CohortMemberEntity;
+import com.prography.backend.domain.member.dto.response.MemberAdminResponse;
+import com.prography.backend.domain.member.dto.response.MemberDashboardItemResponse;
+import com.prography.backend.domain.member.dto.response.MemberWithdrawResponse;
+import com.prography.backend.domain.member.entity.MemberEntity;
+import org.springframework.stereotype.Component;
+
+/**
+ * packageName    : com.prography.backend.domain.member.mapper<br>
+ * fileName       : MemberAdminMapper.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-25<br>
+ * description    : 관리자용 회원 매핑을 담당하는 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-25         cod0216             최초생성<br>
+ */
+@Component
+public class MemberAdminMapper {
+
+    public MemberAdminResponse toAdminResponse(MemberEntity member, CohortMemberEntity cohortMember) {
+        if (member == null) {
+            return null;
+        }
+        return MemberAdminResponse.builder()
+                .id(member.getId())
+                .loginId(member.getLoginId())
+                .name(member.getName())
+                .phone(member.getPhone())
+                .status(member.getStatus())
+                .role(member.getRole())
+                .generation(getGeneration(cohortMember))
+                .partName(getPartName(cohortMember))
+                .teamName(getTeamName(cohortMember))
+                .createdAt(member.getCreatedAt())
+                .updatedAt(member.getUpdatedAt())
+                .build();
+    }
+
+    public MemberDashboardItemResponse toDashboardItem(MemberEntity member, CohortMemberEntity cohortMember) {
+        if (member == null) {
+            return null;
+        }
+        return MemberDashboardItemResponse.builder()
+                .id(member.getId())
+                .loginId(member.getLoginId())
+                .name(member.getName())
+                .phone(member.getPhone())
+                .status(member.getStatus())
+                .role(member.getRole())
+                .generation(getGeneration(cohortMember))
+                .partName(getPartName(cohortMember))
+                .teamName(getTeamName(cohortMember))
+                .deposit(getDeposit(cohortMember))
+                .createdAt(member.getCreatedAt())
+                .updatedAt(member.getUpdatedAt())
+                .build();
+    }
+
+    public MemberWithdrawResponse toWithdrawResponse(MemberEntity member) {
+        if (member == null) {
+            return null;
+        }
+        return MemberWithdrawResponse.builder()
+                .id(member.getId())
+                .loginId(member.getLoginId())
+                .name(member.getName())
+                .status(member.getStatus())
+                .updatedAt(member.getUpdatedAt())
+                .build();
+    }
+
+    private Integer getGeneration(CohortMemberEntity cohortMember) {
+        if (cohortMember == null || cohortMember.getCohort() == null) {
+            return null;
+        }
+        return cohortMember.getCohort().getGeneration();
+    }
+
+    private String getPartName(CohortMemberEntity cohortMember) {
+        if (cohortMember == null || cohortMember.getPart() == null) {
+            return null;
+        }
+        return cohortMember.getPart().getName();
+    }
+
+    private String getTeamName(CohortMemberEntity cohortMember) {
+        if (cohortMember == null || cohortMember.getTeam() == null) {
+            return null;
+        }
+        return cohortMember.getTeam().getName();
+    }
+
+    private Long getDeposit(CohortMemberEntity cohortMember) {
+        if (cohortMember == null) {
+            return null;
+        }
+        return cohortMember.getDeposit();
+    }
+}

--- a/src/main/java/com/prography/backend/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/prography/backend/domain/member/repository/MemberRepository.java
@@ -1,8 +1,10 @@
 package com.prography.backend.domain.member.repository;
 
 import com.prography.backend.domain.member.entity.MemberEntity;
+import com.prography.backend.domain.member.entity.MemberStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -19,4 +21,11 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
     Optional<MemberEntity> findByLoginId(String loginId);
     boolean existsByLoginId(String loginId);
+    List<MemberEntity> findByStatus(MemberStatus status);
+    List<MemberEntity> findByNameContaining(String name);
+    List<MemberEntity> findByLoginIdContaining(String loginId);
+    List<MemberEntity> findByPhoneContaining(String phone);
+    List<MemberEntity> findByStatusAndNameContaining(MemberStatus status, String name);
+    List<MemberEntity> findByStatusAndLoginIdContaining(MemberStatus status, String loginId);
+    List<MemberEntity> findByStatusAndPhoneContaining(MemberStatus status, String phone);
 }

--- a/src/main/java/com/prography/backend/domain/member/service/MemberAdminFacadeService.java
+++ b/src/main/java/com/prography/backend/domain/member/service/MemberAdminFacadeService.java
@@ -1,0 +1,239 @@
+package com.prography.backend.domain.member.service;
+
+import com.prography.backend.domain.cohort.entity.CohortEntity;
+import com.prography.backend.domain.cohort.service.CohortService;
+import com.prography.backend.domain.cohortmember.entity.CohortMemberEntity;
+import com.prography.backend.domain.cohortmember.service.CohortMemberService;
+import com.prography.backend.domain.deposit.service.DepositHistoryService;
+import com.prography.backend.domain.member.dto.request.AdminMemberCreateRequest;
+import com.prography.backend.domain.member.dto.request.AdminMemberUpdateRequest;
+import com.prography.backend.domain.member.dto.request.MemberDashboardQuery;
+import com.prography.backend.domain.member.dto.response.MemberAdminResponse;
+import com.prography.backend.domain.member.dto.response.MemberDashboardItemResponse;
+import com.prography.backend.domain.member.dto.response.MemberWithdrawResponse;
+import com.prography.backend.domain.member.entity.MemberEntity;
+import com.prography.backend.domain.member.entity.MemberRole;
+import com.prography.backend.domain.member.mapper.MemberAdminMapper;
+import com.prography.backend.domain.part.entity.PartEntity;
+import com.prography.backend.domain.part.service.PartService;
+import com.prography.backend.domain.team.entity.TeamEntity;
+import com.prography.backend.domain.team.service.TeamService;
+import com.prography.backend.global.common.PolicyConstants;
+import com.prography.backend.global.common.StatusCode;
+import com.prography.backend.global.error.CustomException;
+import com.prography.backend.global.response.PageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * packageName    : com.prography.backend.domain.member.service<br>
+ * fileName       : MemberAdminFacadeService.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-25<br>
+ * description    : 관리자 회원 API를 위한 파사드 서비스 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-25         cod0216             최초생성<br>
+ */
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberAdminFacadeService {
+
+    private final MemberService memberService;
+    private final CohortService cohortService;
+    private final PartService partService;
+    private final TeamService teamService;
+    private final CohortMemberService cohortMemberService;
+    private final DepositHistoryService depositHistoryService;
+    private final MemberAdminMapper memberAdminMapper;
+    private final PasswordEncoder passwordEncoder;
+
+    public MemberAdminResponse createMember(AdminMemberCreateRequest request) {
+        CohortEntity cohort = cohortService.getById(request.getCohortId());
+        PartEntity part = resolvePart(request.getPartId());
+        TeamEntity team = resolveTeam(request.getTeamId());
+
+        MemberEntity member = memberService.createMember(
+                request.getLoginId(),
+                passwordEncoder.encode(request.getPassword()),
+                request.getName(),
+                request.getPhone(),
+                MemberRole.MEMBER
+        );
+
+        CohortMemberEntity cohortMember = cohortMemberService.create(
+                member,
+                cohort,
+                part,
+                team,
+                PolicyConstants.INITIAL_DEPOSIT
+        );
+
+        depositHistoryService.createInitial(
+                cohortMember,
+                PolicyConstants.INITIAL_DEPOSIT,
+                PolicyConstants.INITIAL_DEPOSIT_DESCRIPTION
+        );
+
+        return memberAdminMapper.toAdminResponse(member, cohortMember);
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponse<MemberDashboardItemResponse> getMemberDashboard(MemberDashboardQuery query) {
+        validateSearchQuery(query.getSearchType(), query.getSearchValue());
+
+        List<MemberEntity> members = memberService.searchMembers(
+                query.getStatus(),
+                query.getSearchType(),
+                query.getSearchValue()
+        );
+
+        List<MemberDashboardItemResponse> items = members.stream()
+                .map(this::toDashboardItem)
+                .filter(item -> matchesGeneration(item, query.getGeneration()))
+                .filter(item -> matchesPartName(item, query.getPartName()))
+                .filter(item -> matchesTeamName(item, query.getTeamName()))
+                .collect(Collectors.toList());
+
+        return paginate(items, query.getPage(), query.getSize());
+    }
+
+    @Transactional(readOnly = true)
+    public MemberAdminResponse getMemberDetail(Long memberId) {
+        MemberEntity member = memberService.getById(memberId);
+        CohortMemberEntity cohortMember = cohortMemberService.findLatestByMemberId(memberId).orElse(null);
+        return memberAdminMapper.toAdminResponse(member, cohortMember);
+    }
+
+    public MemberAdminResponse updateMember(Long memberId, AdminMemberUpdateRequest request) {
+        MemberEntity member = memberService.updateMember(memberId, request.getName(), request.getPhone());
+        CohortMemberEntity cohortMember = updateCohortMember(member, request);
+        return memberAdminMapper.toAdminResponse(member, cohortMember);
+    }
+
+    public MemberWithdrawResponse withdrawMember(Long memberId) {
+        MemberEntity member = memberService.withdrawMember(memberId);
+        return memberAdminMapper.toWithdrawResponse(member);
+    }
+
+    private CohortMemberEntity updateCohortMember(MemberEntity member, AdminMemberUpdateRequest request) {
+        if (request.getCohortId() != null) {
+            CohortEntity cohort = cohortService.getById(request.getCohortId());
+            Optional<CohortMemberEntity> existing = cohortMemberService.findByMemberAndCohort(member.getId(), cohort.getId());
+            if (existing.isPresent()) {
+                updatePartAndTeam(existing.get(), request.getPartId(), request.getTeamId());
+                return existing.get();
+            }
+
+            PartEntity part = resolvePart(request.getPartId());
+            TeamEntity team = resolveTeam(request.getTeamId());
+            CohortMemberEntity created = cohortMemberService.create(member, cohort, part, team, PolicyConstants.INITIAL_DEPOSIT);
+            depositHistoryService.createInitial(created, PolicyConstants.INITIAL_DEPOSIT, PolicyConstants.INITIAL_DEPOSIT_DESCRIPTION);
+            return created;
+        }
+
+        Optional<CohortMemberEntity> latest = cohortMemberService.findLatestByMemberId(member.getId());
+        if (request.getPartId() == null && request.getTeamId() == null) {
+            return latest.orElse(null);
+        }
+
+        CohortEntity currentCohort = cohortService.getByGeneration(PolicyConstants.CURRENT_GENERATION);
+        CohortMemberEntity cohortMember = cohortMemberService.findByMemberAndCohort(member.getId(), currentCohort.getId())
+                .orElseThrow(() -> new CustomException(StatusCode.COHORT_MEMBER_NOT_FOUND));
+        updatePartAndTeam(cohortMember, request.getPartId(), request.getTeamId());
+        return cohortMember;
+    }
+
+    private void updatePartAndTeam(CohortMemberEntity cohortMember, Long partId, Long teamId) {
+        if (partId != null) {
+            cohortMember.updatePart(resolvePart(partId));
+        }
+        if (teamId != null) {
+            cohortMember.updateTeam(resolveTeam(teamId));
+        }
+    }
+
+    private PartEntity resolvePart(Long partId) {
+        if (partId == null) {
+            return null;
+        }
+        return partService.getById(partId);
+    }
+
+    private TeamEntity resolveTeam(Long teamId) {
+        if (teamId == null) {
+            return null;
+        }
+        return teamService.getById(teamId);
+    }
+
+    private MemberDashboardItemResponse toDashboardItem(MemberEntity member) {
+        CohortMemberEntity cohortMember = cohortMemberService.findLatestByMemberId(member.getId()).orElse(null);
+        return memberAdminMapper.toDashboardItem(member, cohortMember);
+    }
+
+    private void validateSearchQuery(String searchType, String searchValue) {
+        if (searchType != null && (searchValue == null || searchValue.isBlank())) {
+            throw new CustomException(StatusCode.INVALID_INPUT);
+        }
+    }
+
+    private boolean matchesGeneration(MemberDashboardItemResponse item, Integer generation) {
+        if (generation == null) {
+            return true;
+        }
+        return generation.equals(item.getGeneration());
+    }
+
+    private boolean matchesPartName(MemberDashboardItemResponse item, String partName) {
+        if (partName == null || partName.isBlank()) {
+            return true;
+        }
+        return partName.equals(item.getPartName());
+    }
+
+    private boolean matchesTeamName(MemberDashboardItemResponse item, String teamName) {
+        if (teamName == null || teamName.isBlank()) {
+            return true;
+        }
+        return teamName.equals(item.getTeamName());
+    }
+
+    private PageResponse<MemberDashboardItemResponse> paginate(List<MemberDashboardItemResponse> items, int page, int size) {
+        int safePage = Math.max(page, 0);
+        int safeSize = size <= 0 ? 10 : size;
+        int totalElements = items.size();
+        int totalPages = (int) Math.ceil((double) totalElements / safeSize);
+
+        int fromIndex = safePage * safeSize;
+        if (fromIndex >= totalElements) {
+            return PageResponse.<MemberDashboardItemResponse>builder()
+                    .content(new ArrayList<>())
+                    .page(safePage)
+                    .size(safeSize)
+                    .totalElements(totalElements)
+                    .totalPages(totalPages)
+                    .build();
+        }
+
+        int toIndex = Math.min(fromIndex + safeSize, totalElements);
+        List<MemberDashboardItemResponse> content = items.subList(fromIndex, toIndex);
+
+        return PageResponse.<MemberDashboardItemResponse>builder()
+                .content(content)
+                .page(safePage)
+                .size(safeSize)
+                .totalElements(totalElements)
+                .totalPages(totalPages)
+                .build();
+    }
+}

--- a/src/main/java/com/prography/backend/domain/member/service/MemberFacadeService.java
+++ b/src/main/java/com/prography/backend/domain/member/service/MemberFacadeService.java
@@ -1,0 +1,33 @@
+package com.prography.backend.domain.member.service;
+
+import com.prography.backend.domain.member.dto.response.MemberResponse;
+import com.prography.backend.domain.member.entity.MemberEntity;
+import com.prography.backend.domain.member.mapper.MemberMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * packageName    : com.prography.backend.domain.member.service<br>
+ * fileName       : MemberFacadeService.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-25<br>
+ * description    : 회원 조회 응답 매핑을 처리하는 파사드 서비스 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-25         cod0216             최초생성<br>
+ */
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberFacadeService {
+
+    private final MemberService memberService;
+    private final MemberMapper memberMapper;
+
+    public MemberResponse getMember(Long memberId) {
+        MemberEntity member = memberService.getById(memberId);
+        return memberMapper.toMemberResponse(member);
+    }
+}

--- a/src/main/java/com/prography/backend/domain/session/entity/SessionEntity.java
+++ b/src/main/java/com/prography/backend/domain/session/entity/SessionEntity.java
@@ -1,0 +1,60 @@
+package com.prography.backend.domain.session.entity;
+
+import com.prography.backend.domain.cohort.entity.CohortEntity;
+import com.prography.backend.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+/**
+ * packageName    : com.prography.backend.domain.session.entity<br>
+ * fileName       : SessionEntity.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 일정 엔티티 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Entity
+@Getter
+@Builder
+@Table(name = "tb_session")
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SessionEntity extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "cohort_id", nullable = false)
+    private CohortEntity cohort;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    @Column(nullable = false)
+    private LocalTime time;
+
+    @Column(nullable = false)
+    private String location;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private SessionStatus status;
+}

--- a/src/main/java/com/prography/backend/domain/session/entity/SessionStatus.java
+++ b/src/main/java/com/prography/backend/domain/session/entity/SessionStatus.java
@@ -1,0 +1,19 @@
+package com.prography.backend.domain.session.entity;
+
+/**
+ * packageName    : com.prography.backend.domain.session.entity<br>
+ * fileName       : SessionStatus.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 일정 상태 enum 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+public enum SessionStatus {
+    SCHEDULED,
+    IN_PROGRESS,
+    COMPLETED,
+    CANCELLED
+}

--- a/src/main/java/com/prography/backend/domain/session/repository/SessionRepository.java
+++ b/src/main/java/com/prography/backend/domain/session/repository/SessionRepository.java
@@ -1,0 +1,18 @@
+package com.prography.backend.domain.session.repository;
+
+import com.prography.backend.domain.session.entity.SessionEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * packageName    : com.prography.backend.domain.session.repository<br>
+ * fileName       : SessionRepository.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 일정 레포지토리 인터페이스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+public interface SessionRepository extends JpaRepository<SessionEntity, Long> {
+}

--- a/src/main/java/com/prography/backend/domain/session/service/SessionService.java
+++ b/src/main/java/com/prography/backend/domain/session/service/SessionService.java
@@ -1,0 +1,33 @@
+package com.prography.backend.domain.session.service;
+
+import com.prography.backend.domain.session.entity.SessionEntity;
+import com.prography.backend.domain.session.repository.SessionRepository;
+import com.prography.backend.global.common.StatusCode;
+import com.prography.backend.global.error.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * packageName    : com.prography.backend.domain.session.service<br>
+ * fileName       : SessionService.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 일정 관련 비즈니스 로직을 처리하는 서비스 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class SessionService {
+
+    private final SessionRepository sessionRepository;
+
+    public SessionEntity getById(Long id) {
+        return sessionRepository.findById(id)
+                .orElseThrow(() -> new CustomException(StatusCode.SESSION_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/prography/backend/global/common/PolicyConstants.java
+++ b/src/main/java/com/prography/backend/global/common/PolicyConstants.java
@@ -20,4 +20,8 @@ public final class PolicyConstants {
     public static final long INITIAL_DEPOSIT = 100_000L;
     public static final String INITIAL_DEPOSIT_DESCRIPTION = "초기 보증금";
     public static final int CURRENT_GENERATION = 11;
+    public static final int EXCUSE_LIMIT = 3;
+    public static final long PENALTY_ABSENT = 10_000L;
+    public static final long PENALTY_LATE_PER_MINUTE = 500L;
+    public static final long PENALTY_MAX = 10_000L;
 }

--- a/src/main/java/com/prography/backend/global/common/PolicyConstants.java
+++ b/src/main/java/com/prography/backend/global/common/PolicyConstants.java
@@ -1,0 +1,22 @@
+package com.prography.backend.global.common;
+
+/**
+ * packageName    : com.prography.backend.global.common<br>
+ * fileName       : PolicyConstants.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-25<br>
+ * description    : 정책 상수를 모아둔 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-25         cod0216             최초생성<br>
+ */
+public final class PolicyConstants {
+
+    private PolicyConstants() {
+        throw new UnsupportedOperationException("Utility 클래스는 생성할 수 없습니다.");
+    }
+
+    public static final long INITIAL_DEPOSIT = 100_000L;
+    public static final String INITIAL_DEPOSIT_DESCRIPTION = "초기 보증금";
+}

--- a/src/main/java/com/prography/backend/global/common/PolicyConstants.java
+++ b/src/main/java/com/prography/backend/global/common/PolicyConstants.java
@@ -19,4 +19,5 @@ public final class PolicyConstants {
 
     public static final long INITIAL_DEPOSIT = 100_000L;
     public static final String INITIAL_DEPOSIT_DESCRIPTION = "초기 보증금";
+    public static final int CURRENT_GENERATION = 11;
 }

--- a/src/main/java/com/prography/backend/global/common/PolicyConstants.java
+++ b/src/main/java/com/prography/backend/global/common/PolicyConstants.java
@@ -10,6 +10,7 @@ package com.prography.backend.global.common;
  * DATE              AUTHOR             NOTE<br>
  * -----------------------------------------------------------<br>
  * 2026-02-25         cod0216             최초생성<br>
+ * 2026-02-24         cod0216             출결 정책 상수 추가<br>
  */
 public final class PolicyConstants {
 

--- a/src/main/java/com/prography/backend/global/response/PageResponse.java
+++ b/src/main/java/com/prography/backend/global/response/PageResponse.java
@@ -1,0 +1,27 @@
+package com.prography.backend.global.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * packageName    : com.prography.backend.global.response<br>
+ * fileName       : PageResponse.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-25<br>
+ * description    : 페이징 응답 DTO 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-25         cod0216             최초생성<br>
+ */
+@Getter
+@Builder
+public class PageResponse<T> {
+    private List<T> content;
+    private int page;
+    private int size;
+    private long totalElements;
+    private int totalPages;
+}

--- a/src/main/java/com/prography/backend/global/util/ResponseUtility.java
+++ b/src/main/java/com/prography/backend/global/util/ResponseUtility.java
@@ -2,6 +2,7 @@ package com.prography.backend.global.util;
 
 import com.prography.backend.global.common.StatusCode;
 import com.prography.backend.global.response.ApiResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 /**
@@ -22,6 +23,10 @@ public final class ResponseUtility {
 
     public static <T> ResponseEntity<ApiResponse<T>> success(T data) {
         return ResponseEntity.ok(ApiResponse.success(data));
+    }
+
+    public static <T> ResponseEntity<ApiResponse<T>> created(T data) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(data));
     }
 
     public static ResponseEntity<ApiResponse<Void>> failure(StatusCode statusCode) {

--- a/src/test/java/com/prography/backend/domain/attendance/service/AdminAttendanceFacadeServiceTest.java
+++ b/src/test/java/com/prography/backend/domain/attendance/service/AdminAttendanceFacadeServiceTest.java
@@ -1,0 +1,164 @@
+package com.prography.backend.domain.attendance.service;
+
+import com.prography.backend.domain.attendance.dto.request.AdminAttendanceRegisterRequest;
+import com.prography.backend.domain.attendance.dto.request.AdminAttendanceUpdateRequest;
+import com.prography.backend.domain.attendance.dto.response.AttendanceResponse;
+import com.prography.backend.domain.attendance.entity.AttendanceStatus;
+import com.prography.backend.domain.cohort.entity.CohortEntity;
+import com.prography.backend.domain.cohort.repository.CohortRepository;
+import com.prography.backend.domain.cohortmember.entity.CohortMemberEntity;
+import com.prography.backend.domain.cohortmember.service.CohortMemberService;
+import com.prography.backend.domain.deposit.entity.DepositHistoryEntity;
+import com.prography.backend.domain.deposit.entity.DepositType;
+import com.prography.backend.domain.deposit.repository.DepositHistoryRepository;
+import com.prography.backend.domain.member.entity.MemberEntity;
+import com.prography.backend.domain.member.entity.MemberRole;
+import com.prography.backend.domain.member.service.MemberService;
+import com.prography.backend.domain.session.entity.SessionEntity;
+import com.prography.backend.domain.session.entity.SessionStatus;
+import com.prography.backend.domain.session.repository.SessionRepository;
+import com.prography.backend.global.common.PolicyConstants;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * packageName    : com.prography.backend.domain.attendance.service<br>
+ * fileName       : AdminAttendanceFacadeServiceTest.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 관리자 출결 파사드 서비스 테스트 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@SpringBootTest
+@Transactional
+class AdminAttendanceFacadeServiceTest {
+
+    @Autowired
+    private AdminAttendanceFacadeService adminAttendanceFacadeService;
+
+    @Autowired
+    private CohortRepository cohortRepository;
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private CohortMemberService cohortMemberService;
+
+    @Autowired
+    private SessionRepository sessionRepository;
+
+    @Autowired
+    private DepositHistoryRepository depositHistoryRepository;
+
+    @Test
+    void registerAttendance_absent_appliesPenaltyAndCreatesHistory() {
+        // Given
+        CohortMemberEntity cohortMember = createCohortMember("user1");
+        SessionEntity session = createSession(cohortMember.getCohort(), "정기 모임");
+
+        AdminAttendanceRegisterRequest request = new AdminAttendanceRegisterRequest();
+        setField(request, "sessionId", session.getId());
+        setField(request, "memberId", cohortMember.getMember().getId());
+        setField(request, "status", AttendanceStatus.ABSENT);
+        setField(request, "lateMinutes", null);
+        setField(request, "reason", "무단 결석");
+
+        // When
+        AttendanceResponse response = adminAttendanceFacadeService.registerAttendance(request);
+
+        // Then
+        assertThat(response.getPenaltyAmount()).isEqualTo(PolicyConstants.PENALTY_ABSENT);
+        assertThat(cohortMemberService.getById(cohortMember.getId()).getDeposit())
+                .isEqualTo(PolicyConstants.INITIAL_DEPOSIT - PolicyConstants.PENALTY_ABSENT);
+
+        List<DepositHistoryEntity> histories = depositHistoryRepository.findByCohortMemberIdOrderByCreatedAtAsc(cohortMember.getId());
+        assertThat(histories).hasSize(1);
+        assertThat(histories.get(0).getType()).isEqualTo(DepositType.PENALTY);
+        assertThat(histories.get(0).getAmount()).isEqualTo(-PolicyConstants.PENALTY_ABSENT);
+        assertThat(histories.get(0).getAttendanceId()).isEqualTo(response.getId());
+    }
+
+    @Test
+    void updateAttendance_absentToExcused_refundsAndUpdatesExcuseCount() {
+        // Given
+        CohortMemberEntity cohortMember = createCohortMember("user2");
+        SessionEntity session = createSession(cohortMember.getCohort(), "정기 모임");
+
+        AdminAttendanceRegisterRequest registerRequest = new AdminAttendanceRegisterRequest();
+        setField(registerRequest, "sessionId", session.getId());
+        setField(registerRequest, "memberId", cohortMember.getMember().getId());
+        setField(registerRequest, "status", AttendanceStatus.ABSENT);
+        setField(registerRequest, "lateMinutes", null);
+        setField(registerRequest, "reason", "무단 결석");
+
+        AttendanceResponse registered = adminAttendanceFacadeService.registerAttendance(registerRequest);
+
+        AdminAttendanceUpdateRequest updateRequest = new AdminAttendanceUpdateRequest();
+        setField(updateRequest, "status", AttendanceStatus.EXCUSED);
+        setField(updateRequest, "lateMinutes", null);
+        setField(updateRequest, "reason", "병가");
+
+        // When
+        AttendanceResponse updated = adminAttendanceFacadeService.updateAttendance(registered.getId(), updateRequest);
+
+        // Then
+        assertThat(updated.getStatus()).isEqualTo(AttendanceStatus.EXCUSED);
+        assertThat(updated.getPenaltyAmount()).isZero();
+        assertThat(cohortMemberService.getById(cohortMember.getId()).getDeposit()).isEqualTo(PolicyConstants.INITIAL_DEPOSIT);
+        assertThat(cohortMemberService.getById(cohortMember.getId()).getExcuseCount()).isEqualTo(1);
+
+        List<DepositHistoryEntity> histories = depositHistoryRepository.findByCohortMemberIdOrderByCreatedAtAsc(cohortMember.getId());
+        assertThat(histories).hasSize(2);
+        assertThat(histories).anyMatch(history -> history.getType() == DepositType.REFUND
+                && history.getAmount().equals(PolicyConstants.PENALTY_ABSENT));
+    }
+
+    private CohortMemberEntity createCohortMember(String loginId) {
+        CohortEntity cohort = cohortRepository.save(CohortEntity.builder().generation(PolicyConstants.CURRENT_GENERATION).name("11기").build());
+        MemberEntity member = memberService.createMember(
+                loginId,
+                passwordEncoder.encode("password123"),
+                "홍길동",
+                "010-1234-5678",
+                MemberRole.MEMBER
+        );
+        return cohortMemberService.create(member, cohort, null, null, PolicyConstants.INITIAL_DEPOSIT);
+    }
+
+    private SessionEntity createSession(CohortEntity cohort, String title) {
+        return sessionRepository.save(SessionEntity.builder()
+                .cohort(cohort)
+                .title(title)
+                .date(LocalDate.of(2026, 2, 24))
+                .time(LocalTime.of(10, 0))
+                .location("강남")
+                .status(SessionStatus.SCHEDULED)
+                .build());
+    }
+
+    private void setField(Object target, String fieldName, Object value) {
+        try {
+            java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/src/test/java/com/prography/backend/domain/deposit/service/DepositHistoryAdminFacadeServiceTest.java
+++ b/src/test/java/com/prography/backend/domain/deposit/service/DepositHistoryAdminFacadeServiceTest.java
@@ -1,0 +1,135 @@
+package com.prography.backend.domain.deposit.service;
+
+import com.prography.backend.domain.cohort.entity.CohortEntity;
+import com.prography.backend.domain.cohort.repository.CohortRepository;
+import com.prography.backend.domain.cohortmember.entity.CohortMemberEntity;
+import com.prography.backend.domain.cohortmember.service.CohortMemberService;
+import com.prography.backend.domain.deposit.dto.response.DepositHistoryResponse;
+import com.prography.backend.domain.deposit.entity.DepositHistoryEntity;
+import com.prography.backend.domain.deposit.entity.DepositType;
+import com.prography.backend.domain.deposit.repository.DepositHistoryRepository;
+import com.prography.backend.domain.member.entity.MemberEntity;
+import com.prography.backend.domain.member.entity.MemberRole;
+import com.prography.backend.domain.member.service.MemberService;
+import com.prography.backend.global.common.StatusCode;
+import com.prography.backend.global.error.CustomException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * packageName    : com.prography.backend.domain.deposit.service<br>
+ * fileName       : DepositHistoryAdminFacadeServiceTest.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 관리자 보증금 이력 파사드 서비스 테스트 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@SpringBootTest
+@Transactional
+class DepositHistoryAdminFacadeServiceTest {
+
+    @Autowired
+    private DepositHistoryAdminFacadeService depositHistoryAdminFacadeService;
+
+    @Autowired
+    private DepositHistoryRepository depositHistoryRepository;
+
+    @Autowired
+    private CohortMemberService cohortMemberService;
+
+    @Autowired
+    private CohortRepository cohortRepository;
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    void getDepositHistories_returnsOrderedHistoryList() {
+        // Given
+        CohortMemberEntity cohortMember = createCohortMember("member-1");
+        DepositHistoryEntity third = saveHistory(cohortMember, DepositType.REFUND, 10_000L, 100_000L, 1L, "환급");
+        DepositHistoryEntity first = saveHistory(cohortMember, DepositType.INITIAL, 100_000L, 100_000L, null, "초기 보증금");
+        DepositHistoryEntity second = saveHistory(cohortMember, DepositType.PENALTY, -10_000L, 90_000L, 1L, "패널티");
+
+        updateCreatedAt(first.getId(), LocalDateTime.of(2026, 2, 24, 9, 0, 0));
+        updateCreatedAt(second.getId(), LocalDateTime.of(2026, 2, 24, 10, 0, 0));
+        updateCreatedAt(third.getId(), LocalDateTime.of(2026, 2, 24, 11, 0, 0));
+
+        // When
+        List<DepositHistoryResponse> histories = depositHistoryAdminFacadeService.getDepositHistories(cohortMember.getId());
+
+        // Then
+        assertThat(histories).hasSize(3);
+        assertThat(histories).extracting(DepositHistoryResponse::getType)
+                .containsExactly(DepositType.INITIAL, DepositType.PENALTY, DepositType.REFUND);
+        assertThat(histories).extracting(DepositHistoryResponse::getAmount)
+                .containsExactly(100_000L, -10_000L, 10_000L);
+        assertThat(histories).allSatisfy(history ->
+                assertThat(history.getCohortMemberId()).isEqualTo(cohortMember.getId()));
+    }
+
+    @Test
+    void getDepositHistories_whenCohortMemberMissing_throwsCohortMemberNotFound() {
+        // Given
+        Long missingCohortMemberId = 9999L;
+
+        // When & Then
+        assertThatThrownBy(() -> depositHistoryAdminFacadeService.getDepositHistories(missingCohortMemberId))
+                .isInstanceOf(CustomException.class)
+                .extracting("statusCode")
+                .isEqualTo(StatusCode.COHORT_MEMBER_NOT_FOUND);
+    }
+
+    private CohortMemberEntity createCohortMember(String loginId) {
+        CohortEntity cohort = cohortRepository.save(CohortEntity.builder().generation(11).name("11기").build());
+        MemberEntity member = memberService.createMember(
+                loginId,
+                passwordEncoder.encode("password123"),
+                "홍길동",
+                "010-1234-5678",
+                MemberRole.MEMBER
+        );
+
+        return cohortMemberService.create(member, cohort, null, null, 100_000L);
+    }
+
+    private DepositHistoryEntity saveHistory(CohortMemberEntity cohortMember, DepositType type, Long amount, Long balanceAfter,
+                                             Long attendanceId, String description) {
+        return depositHistoryRepository.save(DepositHistoryEntity.builder()
+                .cohortMember(cohortMember)
+                .type(type)
+                .amount(amount)
+                .balanceAfter(balanceAfter)
+                .attendanceId(attendanceId)
+                .description(description)
+                .build());
+    }
+
+    private void updateCreatedAt(Long id, LocalDateTime createdAt) {
+        jdbcTemplate.update(
+                "update tb_deposit_history set created_at = ? where id = ?",
+                Timestamp.valueOf(createdAt),
+                id
+        );
+    }
+}

--- a/src/test/java/com/prography/backend/domain/member/service/MemberAdminFacadeServiceTest.java
+++ b/src/test/java/com/prography/backend/domain/member/service/MemberAdminFacadeServiceTest.java
@@ -4,6 +4,7 @@ import com.prography.backend.domain.cohort.entity.CohortEntity;
 import com.prography.backend.domain.cohort.repository.CohortRepository;
 import com.prography.backend.domain.cohortmember.entity.CohortMemberEntity;
 import com.prography.backend.domain.cohortmember.repository.CohortMemberRepository;
+import com.prography.backend.domain.cohortmember.service.CohortMemberService;
 import com.prography.backend.domain.deposit.entity.DepositHistoryEntity;
 import com.prography.backend.domain.deposit.repository.DepositHistoryRepository;
 import com.prography.backend.domain.member.dto.request.AdminMemberCreateRequest;

--- a/src/test/java/com/prography/backend/domain/member/service/MemberAdminFacadeServiceTest.java
+++ b/src/test/java/com/prography/backend/domain/member/service/MemberAdminFacadeServiceTest.java
@@ -1,0 +1,199 @@
+package com.prography.backend.domain.member.service;
+
+import com.prography.backend.domain.cohort.entity.CohortEntity;
+import com.prography.backend.domain.cohort.repository.CohortRepository;
+import com.prography.backend.domain.cohortmember.entity.CohortMemberEntity;
+import com.prography.backend.domain.cohortmember.repository.CohortMemberRepository;
+import com.prography.backend.domain.deposit.entity.DepositHistoryEntity;
+import com.prography.backend.domain.deposit.repository.DepositHistoryRepository;
+import com.prography.backend.domain.member.dto.request.AdminMemberCreateRequest;
+import com.prography.backend.domain.member.dto.request.AdminMemberUpdateRequest;
+import com.prography.backend.domain.member.dto.request.MemberDashboardQuery;
+import com.prography.backend.domain.member.dto.response.MemberAdminResponse;
+import com.prography.backend.domain.member.dto.response.MemberDashboardItemResponse;
+import com.prography.backend.domain.part.entity.PartEntity;
+import com.prography.backend.domain.part.repository.PartRepository;
+import com.prography.backend.domain.team.entity.TeamEntity;
+import com.prography.backend.domain.team.repository.TeamRepository;
+import com.prography.backend.global.common.PolicyConstants;
+import com.prography.backend.global.response.PageResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * packageName    : com.prography.backend.domain.member.service<br>
+ * fileName       : MemberAdminFacadeServiceTest.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-25<br>
+ * description    : 관리자 회원 파사드 서비스 테스트 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-25         cod0216             최초생성<br>
+ */
+@SpringBootTest
+@Transactional
+class MemberAdminFacadeServiceTest {
+
+    @Autowired
+    private MemberAdminFacadeService memberAdminFacadeService;
+
+    @Autowired
+    private CohortRepository cohortRepository;
+
+    @Autowired
+    private PartRepository partRepository;
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Autowired
+    private CohortMemberRepository cohortMemberRepository;
+
+    @Autowired
+    private CohortMemberService cohortMemberService;
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private DepositHistoryRepository depositHistoryRepository;
+
+    @Test
+    void createMember_createsCohortMemberAndDepositHistory() {
+        // Given
+        CohortEntity cohort = cohortRepository.save(CohortEntity.builder().generation(11).name("11기").build());
+        PartEntity part = partRepository.save(PartEntity.builder().name("SERVER").cohort(cohort).build());
+        TeamEntity team = teamRepository.save(TeamEntity.builder().name("Team A").cohort(cohort).build());
+
+        AdminMemberCreateRequest request = buildCreateRequest("user1", "password123", "홍길동", "010-1234-5678", cohort.getId(), part.getId(), team.getId());
+
+        // When
+        MemberAdminResponse response = memberAdminFacadeService.createMember(request);
+
+        // Then
+        CohortMemberEntity cohortMember = cohortMemberRepository.findFirstByMemberIdOrderByIdDesc(response.getId()).orElseThrow();
+        assertThat(cohortMember.getDeposit()).isEqualTo(PolicyConstants.INITIAL_DEPOSIT);
+
+        List<DepositHistoryEntity> histories = depositHistoryRepository.findByCohortMemberIdOrderByCreatedAtAsc(cohortMember.getId());
+        assertThat(histories).hasSize(1);
+        assertThat(histories.get(0).getAmount()).isEqualTo(PolicyConstants.INITIAL_DEPOSIT);
+        assertThat(histories.get(0).getBalanceAfter()).isEqualTo(PolicyConstants.INITIAL_DEPOSIT);
+    }
+
+    @Test
+    void getMemberDashboard_filtersByGeneration() {
+        // Given
+        CohortEntity cohort10 = cohortRepository.save(CohortEntity.builder().generation(10).name("10기").build());
+        CohortEntity cohort11 = cohortRepository.save(CohortEntity.builder().generation(11).name("11기").build());
+
+        AdminMemberCreateRequest request1 = buildCreateRequest("user10", "password123", "홍길동", "010-1111-1111", cohort10.getId(), null, null);
+        AdminMemberCreateRequest request2 = buildCreateRequest("user11", "password123", "성춘향", "010-2222-2222", cohort11.getId(), null, null);
+        memberAdminFacadeService.createMember(request1);
+        memberAdminFacadeService.createMember(request2);
+
+        MemberDashboardQuery query = MemberDashboardQuery.builder()
+                .page(0)
+                .size(10)
+                .generation(11)
+                .build();
+
+        // When
+        PageResponse<MemberDashboardItemResponse> result = memberAdminFacadeService.getMemberDashboard(query);
+
+        // Then
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getGeneration()).isEqualTo(11);
+    }
+
+    @Test
+    void updateMember_updatesPartAndTeam() {
+        // Given
+        CohortEntity cohort = cohortRepository.save(CohortEntity.builder().generation(11).name("11기").build());
+        PartEntity part1 = partRepository.save(PartEntity.builder().name("SERVER").cohort(cohort).build());
+        PartEntity part2 = partRepository.save(PartEntity.builder().name("WEB").cohort(cohort).build());
+        TeamEntity team1 = teamRepository.save(TeamEntity.builder().name("Team A").cohort(cohort).build());
+        TeamEntity team2 = teamRepository.save(TeamEntity.builder().name("Team B").cohort(cohort).build());
+
+        AdminMemberCreateRequest request = buildCreateRequest("user2", "password123", "이몽룡", "010-3333-3333", cohort.getId(), part1.getId(), team1.getId());
+        MemberAdminResponse created = memberAdminFacadeService.createMember(request);
+
+        AdminMemberUpdateRequest updateRequest = buildUpdateRequest(null, null, null, part2.getId(), team2.getId());
+
+        // When
+        MemberAdminResponse updated = memberAdminFacadeService.updateMember(created.getId(), updateRequest);
+
+        // Then
+        assertThat(updated.getPartName()).isEqualTo("WEB");
+        assertThat(updated.getTeamName()).isEqualTo("Team B");
+    }
+
+    @Test
+    void updateMember_withoutCohort_updatesCurrentGenerationOnly() {
+        // Given
+        CohortEntity cohort10 = cohortRepository.save(CohortEntity.builder().generation(10).name("10기").build());
+        CohortEntity cohort11 = cohortRepository.save(CohortEntity.builder().generation(11).name("11기").build());
+        PartEntity part10 = partRepository.save(PartEntity.builder().name("SERVER").cohort(cohort10).build());
+        PartEntity part11 = partRepository.save(PartEntity.builder().name("WEB").cohort(cohort11).build());
+        TeamEntity team11 = teamRepository.save(TeamEntity.builder().name("Team A").cohort(cohort11).build());
+
+        AdminMemberCreateRequest request = buildCreateRequest("user3", "password123", "임꺽정", "010-4444-4444", cohort11.getId(), part11.getId(), team11.getId());
+        MemberAdminResponse created = memberAdminFacadeService.createMember(request);
+
+        CohortMemberEntity cohortMember10 = cohortMemberService.create(
+                memberService.getById(created.getId()),
+                cohort10,
+                part10,
+                null,
+                PolicyConstants.INITIAL_DEPOSIT
+        );
+
+        // When
+        AdminMemberUpdateRequest updateRequest = buildUpdateRequest(null, null, null, part11.getId(), team11.getId());
+        MemberAdminResponse updated = memberAdminFacadeService.updateMember(created.getId(), updateRequest);
+
+        // Then
+        assertThat(updated.getGeneration()).isEqualTo(11);
+        assertThat(updated.getPartName()).isEqualTo("WEB");
+        assertThat(cohortMember10.getPart().getName()).isEqualTo("SERVER");
+    }
+
+    private AdminMemberCreateRequest buildCreateRequest(String loginId, String password, String name, String phone,
+                                                        Long cohortId, Long partId, Long teamId) {
+        AdminMemberCreateRequest request = new AdminMemberCreateRequest();
+        setField(request, "loginId", loginId);
+        setField(request, "password", password);
+        setField(request, "name", name);
+        setField(request, "phone", phone);
+        setField(request, "cohortId", cohortId);
+        setField(request, "partId", partId);
+        setField(request, "teamId", teamId);
+        return request;
+    }
+
+    private AdminMemberUpdateRequest buildUpdateRequest(String name, String phone, Long cohortId, Long partId, Long teamId) {
+        AdminMemberUpdateRequest request = new AdminMemberUpdateRequest();
+        setField(request, "name", name);
+        setField(request, "phone", phone);
+        setField(request, "cohortId", cohortId);
+        setField(request, "partId", partId);
+        setField(request, "teamId", teamId);
+        return request;
+    }
+
+    private void setField(Object target, String fieldName, Object value) {
+        try {
+            java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/src/test/java/com/prography/backend/global/response/ResponseUtilityTest.java
+++ b/src/test/java/com/prography/backend/global/response/ResponseUtilityTest.java
@@ -51,4 +51,19 @@ class ResponseUtilityTest {
         assertThat(response.getBody().getData()).isNull();
         assertThat(response.getBody().getError().getCode()).isEqualTo(statusCode.getCode());
     }
+
+    @Test
+    void created_returnsCreatedResponse() {
+        // Given
+        String data = "created";
+
+        // When
+        ResponseEntity<ApiResponse<String>> response = ResponseUtility.created(data);
+
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().isSuccess()).isTrue();
+        assertThat(response.getBody().getData()).isEqualTo(data);
+    }
 }


### PR DESCRIPTION

  ## #️⃣ 관련 이슈
- #7 

## 📝 작업 내용
  - 관리자 회원 관리 API 구현 (등록/목록/상세/수정/탈퇴)
  - 보증금 이력 조회 API 추가
  - 관리자 출결 API 구현 (등록/수정/세션요약/회원상세/세션출결)
  - attendance/session 도메인 추가
  - 보증금 PENALTY/REFUND 이력 생성 로직 및 출결 정책 상수 추가
  - 컨트롤러 매퍼 의존 제거(파사드 위임)

## ✅ 테스트 결과
  - [x] ./gradlew test --tests "com.prography.backend.domain.member.service.MemberAdminFacadeServiceTest"
  - [x] ./gradlew test --tests "com.prography.backend.domain.deposit.service.DepositHistoryAdminFacadeServiceTest"
  - [x] ./gradlew test --tests "com.prography.backend.domain.attendance.service.AdminAttendanceFacadeServiceTest"