### PR TITLE
feat: member attendance apis

### DIFF
--- a/src/main/java/com/prography/backend/domain/attendance/controller/AttendanceController.java
+++ b/src/main/java/com/prography/backend/domain/attendance/controller/AttendanceController.java
@@ -1,0 +1,48 @@
+package com.prography.backend.domain.attendance.controller;
+
+import com.prography.backend.domain.attendance.dto.request.MemberAttendanceCheckInRequest;
+import com.prography.backend.domain.attendance.dto.response.AttendanceResponse;
+import com.prography.backend.domain.attendance.dto.response.MemberAttendanceResponse;
+import com.prography.backend.domain.attendance.service.MemberAttendanceFacadeService;
+import com.prography.backend.global.response.ApiResponse;
+import com.prography.backend.global.util.ResponseUtility;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * packageName    : com.prography.backend.domain.attendance.controller<br>
+ * fileName       : AttendanceController.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 회원 출결 API를 처리하는 컨트롤러 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/attendances")
+public class AttendanceController {
+
+    private final MemberAttendanceFacadeService memberAttendanceFacadeService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<AttendanceResponse>> checkIn(@RequestBody @Valid MemberAttendanceCheckInRequest request) {
+        return ResponseUtility.created(memberAttendanceFacadeService.checkIn(request));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<MemberAttendanceResponse>>> getAttendances(@RequestParam Long memberId) {
+        return ResponseUtility.success(memberAttendanceFacadeService.getAttendances(memberId));
+    }
+}

--- a/src/main/java/com/prography/backend/domain/attendance/dto/request/MemberAttendanceCheckInRequest.java
+++ b/src/main/java/com/prography/backend/domain/attendance/dto/request/MemberAttendanceCheckInRequest.java
@@ -1,0 +1,26 @@
+package com.prography.backend.domain.attendance.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+/**
+ * packageName    : com.prography.backend.domain.attendance.dto.request<br>
+ * fileName       : MemberAttendanceCheckInRequest.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 회원 QR 출석 체크 요청 DTO 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Getter
+public class MemberAttendanceCheckInRequest {
+
+    @NotBlank(message = "hashValue는 필수입니다.")
+    private String hashValue;
+
+    @NotNull(message = "memberId는 필수입니다.")
+    private Long memberId;
+}

--- a/src/main/java/com/prography/backend/domain/attendance/dto/response/MemberAttendanceResponse.java
+++ b/src/main/java/com/prography/backend/domain/attendance/dto/response/MemberAttendanceResponse.java
@@ -1,0 +1,32 @@
+package com.prography.backend.domain.attendance.dto.response;
+
+import com.prography.backend.domain.attendance.entity.AttendanceStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * packageName    : com.prography.backend.domain.attendance.dto.response<br>
+ * fileName       : MemberAttendanceResponse.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 회원 출결 기록 응답 DTO 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Getter
+@Builder
+public class MemberAttendanceResponse {
+    private Long id;
+    private Long sessionId;
+    private String sessionTitle;
+    private AttendanceStatus status;
+    private Integer lateMinutes;
+    private Long penaltyAmount;
+    private String reason;
+    private LocalDateTime checkedInAt;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/prography/backend/domain/attendance/dto/response/MemberAttendanceSummaryResponse.java
+++ b/src/main/java/com/prography/backend/domain/attendance/dto/response/MemberAttendanceSummaryResponse.java
@@ -1,0 +1,27 @@
+package com.prography.backend.domain.attendance.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * packageName    : com.prography.backend.domain.attendance.dto.response<br>
+ * fileName       : MemberAttendanceSummaryResponse.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 회원 출결 요약 응답 DTO 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Getter
+@Builder
+public class MemberAttendanceSummaryResponse {
+    private Long memberId;
+    private int present;
+    private int absent;
+    private int late;
+    private int excused;
+    private Long totalPenalty;
+    private Long deposit;
+}

--- a/src/main/java/com/prography/backend/domain/attendance/mapper/AttendanceMapper.java
+++ b/src/main/java/com/prography/backend/domain/attendance/mapper/AttendanceMapper.java
@@ -1,0 +1,59 @@
+package com.prography.backend.domain.attendance.mapper;
+
+import com.prography.backend.domain.attendance.dto.response.AttendanceResponse;
+import com.prography.backend.domain.attendance.dto.response.MemberAttendanceResponse;
+import com.prography.backend.domain.attendance.entity.AttendanceEntity;
+import org.springframework.stereotype.Component;
+
+/**
+ * packageName    : com.prography.backend.domain.attendance.mapper<br>
+ * fileName       : AttendanceMapper.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 출결 응답 매핑을 담당하는 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ * 2026-02-24         cod0216             회원 출결 응답 매핑 추가<br>
+ */
+@Component
+public class AttendanceMapper {
+
+    public AttendanceResponse toResponse(AttendanceEntity attendance) {
+        if (attendance == null) {
+            return null;
+        }
+
+        return AttendanceResponse.builder()
+                .id(attendance.getId())
+                .sessionId(attendance.getSession().getId())
+                .memberId(attendance.getMember().getId())
+                .status(attendance.getStatus())
+                .lateMinutes(attendance.getLateMinutes())
+                .penaltyAmount(attendance.getPenaltyAmount())
+                .reason(attendance.getReason())
+                .checkedInAt(attendance.getCheckedInAt())
+                .createdAt(attendance.getCreatedAt())
+                .updatedAt(attendance.getUpdatedAt())
+                .build();
+    }
+
+    public MemberAttendanceResponse toMemberResponse(AttendanceEntity attendance) {
+        if (attendance == null) {
+            return null;
+        }
+
+        return MemberAttendanceResponse.builder()
+                .id(attendance.getId())
+                .sessionId(attendance.getSession().getId())
+                .sessionTitle(attendance.getSession().getTitle())
+                .status(attendance.getStatus())
+                .lateMinutes(attendance.getLateMinutes())
+                .penaltyAmount(attendance.getPenaltyAmount())
+                .reason(attendance.getReason())
+                .checkedInAt(attendance.getCheckedInAt())
+                .createdAt(attendance.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/prography/backend/domain/attendance/service/AdminAttendanceFacadeService.java
+++ b/src/main/java/com/prography/backend/domain/attendance/service/AdminAttendanceFacadeService.java
@@ -1,0 +1,269 @@
+package com.prography.backend.domain.attendance.service;
+
+import com.prography.backend.domain.attendance.dto.request.AdminAttendanceRegisterRequest;
+import com.prography.backend.domain.attendance.dto.request.AdminAttendanceUpdateRequest;
+import com.prography.backend.domain.attendance.dto.response.AdminMemberAttendanceDetailResponse;
+import com.prography.backend.domain.attendance.dto.response.AdminSessionAttendanceSummaryResponse;
+import com.prography.backend.domain.attendance.dto.response.AdminSessionAttendancesResponse;
+import com.prography.backend.domain.attendance.dto.response.AttendanceResponse;
+import com.prography.backend.domain.attendance.entity.AttendanceEntity;
+import com.prography.backend.domain.attendance.entity.AttendanceStatus;
+import com.prography.backend.domain.attendance.mapper.AttendanceMapper;
+import com.prography.backend.domain.cohort.entity.CohortEntity;
+import com.prography.backend.domain.cohort.service.CohortService;
+import com.prography.backend.domain.cohortmember.entity.CohortMemberEntity;
+import com.prography.backend.domain.cohortmember.service.CohortMemberService;
+import com.prography.backend.domain.deposit.service.DepositHistoryService;
+import com.prography.backend.domain.member.entity.MemberEntity;
+import com.prography.backend.domain.member.service.MemberService;
+import com.prography.backend.domain.part.entity.PartEntity;
+import com.prography.backend.domain.session.entity.SessionEntity;
+import com.prography.backend.domain.session.service.SessionService;
+import com.prography.backend.domain.team.entity.TeamEntity;
+import com.prography.backend.global.common.PolicyConstants;
+import com.prography.backend.global.common.StatusCode;
+import com.prography.backend.global.error.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * packageName    : com.prography.backend.domain.attendance.service<br>
+ * fileName       : AdminAttendanceFacadeService.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 관리자 출결 API를 위한 파사드 서비스 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ * 2026-02-24         cod0216             QR 코드 없는 수동 출결 등록 처리<br>
+ */
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AdminAttendanceFacadeService {
+
+    private final AttendanceService attendanceService;
+    private final AttendanceMapper attendanceMapper;
+    private final SessionService sessionService;
+    private final MemberService memberService;
+    private final CohortService cohortService;
+    private final CohortMemberService cohortMemberService;
+    private final DepositHistoryService depositHistoryService;
+
+    public AttendanceResponse registerAttendance(AdminAttendanceRegisterRequest request) {
+        SessionEntity session = sessionService.getById(request.getSessionId());
+        MemberEntity member = memberService.getById(request.getMemberId());
+
+        if (attendanceService.existsBySessionAndMember(session.getId(), member.getId())) {
+            throw new CustomException(StatusCode.ATTENDANCE_ALREADY_CHECKED);
+        }
+
+        CohortMemberEntity cohortMember = getCurrentCohortMember(member.getId());
+        AttendanceStatus status = request.getStatus();
+        Integer lateMinutes = normalizeLateMinutes(status, request.getLateMinutes());
+
+        if (status == AttendanceStatus.EXCUSED) {
+            validateExcuseLimit(cohortMember.getExcuseCount());
+            cohortMember.updateExcuseCount(cohortMember.getExcuseCount() + 1);
+        }
+
+        long penaltyAmount = calculatePenalty(status, lateMinutes);
+        AttendanceEntity attendance = attendanceService.create(
+                session,
+                member,
+                status,
+                lateMinutes,
+                penaltyAmount,
+                request.getReason(),
+                null,
+                null
+        );
+
+        if (penaltyAmount > 0) {
+            applyPenalty(cohortMember, penaltyAmount, attendance.getId(), "출결 등록 - " + status + " 패널티 " + penaltyAmount + "원");
+        }
+
+        return attendanceMapper.toResponse(attendance);
+    }
+
+    public AttendanceResponse updateAttendance(Long attendanceId, AdminAttendanceUpdateRequest request) {
+        AttendanceEntity attendance = attendanceService.getById(attendanceId);
+        CohortMemberEntity cohortMember = getCurrentCohortMember(attendance.getMember().getId());
+
+        AttendanceStatus oldStatus = attendance.getStatus();
+        AttendanceStatus newStatus = request.getStatus();
+        Integer lateMinutes = normalizeLateMinutes(newStatus, request.getLateMinutes());
+
+        long oldPenalty = attendance.getPenaltyAmount();
+        long newPenalty = calculatePenalty(newStatus, lateMinutes);
+        long diff = newPenalty - oldPenalty;
+
+        adjustExcuseCount(cohortMember, oldStatus, newStatus);
+        applyDepositDiff(cohortMember, diff, attendance.getId(), newStatus);
+
+        attendance.updateByAdmin(newStatus, lateMinutes, newPenalty, request.getReason());
+        return attendanceMapper.toResponse(attendance);
+    }
+
+    @Transactional(readOnly = true)
+    public List<AdminSessionAttendanceSummaryResponse> getSessionSummary(Long sessionId) {
+        sessionService.getById(sessionId);
+
+        List<CohortMemberEntity> cohortMembers = cohortMemberService.getByGeneration(PolicyConstants.CURRENT_GENERATION);
+
+        List<Long> memberIds = cohortMembers.stream()
+                .map(cohortMember -> cohortMember.getMember().getId())
+                .toList();
+
+        Map<Long, List<AttendanceEntity>> attendanceMap = attendanceService.getByMemberIds(memberIds).stream()
+                .collect(Collectors.groupingBy(attendance -> attendance.getMember().getId()));
+
+        List<AdminSessionAttendanceSummaryResponse> results = new ArrayList<>();
+        for (CohortMemberEntity cohortMember : cohortMembers) {
+            Long memberId = cohortMember.getMember().getId();
+            List<AttendanceEntity> attendances = attendanceMap.getOrDefault(memberId, List.of());
+
+            int present = countStatus(attendances, AttendanceStatus.PRESENT);
+            int absent = countStatus(attendances, AttendanceStatus.ABSENT);
+            int late = countStatus(attendances, AttendanceStatus.LATE);
+            int excused = countStatus(attendances, AttendanceStatus.EXCUSED);
+            long totalPenalty = attendances.stream()
+                    .mapToLong(AttendanceEntity::getPenaltyAmount)
+                    .sum();
+
+            results.add(AdminSessionAttendanceSummaryResponse.builder()
+                    .memberId(memberId)
+                    .memberName(cohortMember.getMember().getName())
+                    .present(present)
+                    .absent(absent)
+                    .late(late)
+                    .excused(excused)
+                    .totalPenalty(totalPenalty)
+                    .deposit(cohortMember.getDeposit())
+                    .build());
+        }
+
+        return results;
+    }
+
+    @Transactional(readOnly = true)
+    public AdminMemberAttendanceDetailResponse getMemberAttendanceDetail(Long memberId) {
+        MemberEntity member = memberService.getById(memberId);
+        List<AttendanceResponse> attendances = attendanceService.getByMemberId(memberId).stream()
+                .map(attendanceMapper::toResponse)
+                .toList();
+
+        CohortEntity cohort = cohortService.getByGeneration(PolicyConstants.CURRENT_GENERATION);
+        Optional<CohortMemberEntity> cohortMember = cohortMemberService.findByMemberAndCohort(memberId, cohort.getId());
+
+        PartEntity part = cohortMember.map(CohortMemberEntity::getPart).orElse(null);
+        TeamEntity team = cohortMember.map(CohortMemberEntity::getTeam).orElse(null);
+
+        return AdminMemberAttendanceDetailResponse.builder()
+                .memberId(member.getId())
+                .memberName(member.getName())
+                .generation(cohortMember.map(cm -> cm.getCohort().getGeneration()).orElse(null))
+                .partName(part == null ? null : part.getName())
+                .teamName(team == null ? null : team.getName())
+                .deposit(cohortMember.map(CohortMemberEntity::getDeposit).orElse(null))
+                .excuseCount(cohortMember.map(CohortMemberEntity::getExcuseCount).orElse(null))
+                .attendances(attendances)
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public AdminSessionAttendancesResponse getSessionAttendances(Long sessionId) {
+        SessionEntity session = sessionService.getById(sessionId);
+        List<AttendanceResponse> attendances = attendanceService.getBySessionId(sessionId).stream()
+                .map(attendanceMapper::toResponse)
+                .toList();
+
+        return AdminSessionAttendancesResponse.builder()
+                .sessionId(session.getId())
+                .sessionTitle(session.getTitle())
+                .attendances(attendances)
+                .build();
+    }
+
+    private CohortMemberEntity getCurrentCohortMember(Long memberId) {
+        CohortEntity cohort = cohortService.getByGeneration(PolicyConstants.CURRENT_GENERATION);
+        return cohortMemberService.findByMemberAndCohort(memberId, cohort.getId())
+                .orElseThrow(() -> new CustomException(StatusCode.COHORT_MEMBER_NOT_FOUND));
+    }
+
+    private Integer normalizeLateMinutes(AttendanceStatus status, Integer lateMinutes) {
+        if (status == AttendanceStatus.LATE) {
+            if (lateMinutes == null) {
+                throw new CustomException(StatusCode.INVALID_INPUT);
+            }
+            if (lateMinutes < 0) {
+                throw new CustomException(StatusCode.INVALID_INPUT);
+            }
+            return lateMinutes;
+        }
+        return null;
+    }
+
+    private long calculatePenalty(AttendanceStatus status, Integer lateMinutes) {
+        return switch (status) {
+            case PRESENT, EXCUSED -> 0;
+            case ABSENT -> PolicyConstants.PENALTY_ABSENT;
+            case LATE -> Math.min((long) lateMinutes * PolicyConstants.PENALTY_LATE_PER_MINUTE, PolicyConstants.PENALTY_MAX);
+        };
+    }
+
+    private void validateExcuseLimit(int excuseCount) {
+        if (excuseCount >= PolicyConstants.EXCUSE_LIMIT) {
+            throw new CustomException(StatusCode.EXCUSE_LIMIT_EXCEEDED);
+        }
+    }
+
+    private void adjustExcuseCount(CohortMemberEntity cohortMember, AttendanceStatus oldStatus, AttendanceStatus newStatus) {
+        if (oldStatus != AttendanceStatus.EXCUSED && newStatus == AttendanceStatus.EXCUSED) {
+            validateExcuseLimit(cohortMember.getExcuseCount());
+            cohortMember.updateExcuseCount(cohortMember.getExcuseCount() + 1);
+        } else if (oldStatus == AttendanceStatus.EXCUSED && newStatus != AttendanceStatus.EXCUSED) {
+            cohortMember.updateExcuseCount(Math.max(0, cohortMember.getExcuseCount() - 1));
+        }
+    }
+
+    private void applyDepositDiff(CohortMemberEntity cohortMember, long diff, Long attendanceId, AttendanceStatus status) {
+        if (diff == 0) {
+            return;
+        }
+
+        if (diff > 0) {
+            applyPenalty(cohortMember, diff, attendanceId, "출결 수정 - " + status + " 패널티 " + diff + "원");
+            return;
+        }
+
+        long refundAmount = Math.abs(diff);
+        long newDeposit = cohortMember.getDeposit() + refundAmount;
+        cohortMember.updateDeposit(newDeposit);
+        depositHistoryService.createRefund(cohortMember, refundAmount, attendanceId, "출결 수정 - 환급 " + refundAmount + "원");
+    }
+
+    private void applyPenalty(CohortMemberEntity cohortMember, long penaltyAmount, Long attendanceId, String description) {
+        if (cohortMember.getDeposit() < penaltyAmount) {
+            throw new CustomException(StatusCode.DEPOSIT_INSUFFICIENT);
+        }
+
+        long newDeposit = cohortMember.getDeposit() - penaltyAmount;
+        cohortMember.updateDeposit(newDeposit);
+        depositHistoryService.createPenalty(cohortMember, penaltyAmount, attendanceId, description);
+    }
+
+    private int countStatus(List<AttendanceEntity> attendances, AttendanceStatus status) {
+        return (int) attendances.stream()
+                .filter(attendance -> attendance.getStatus() == status)
+                .count();
+    }
+}

--- a/src/main/java/com/prography/backend/domain/attendance/service/AttendanceService.java
+++ b/src/main/java/com/prography/backend/domain/attendance/service/AttendanceService.java
@@ -1,0 +1,82 @@
+package com.prography.backend.domain.attendance.service;
+
+import com.prography.backend.domain.attendance.entity.AttendanceEntity;
+import com.prography.backend.domain.attendance.entity.AttendanceStatus;
+import com.prography.backend.domain.attendance.repository.AttendanceRepository;
+import com.prography.backend.domain.member.entity.MemberEntity;
+import com.prography.backend.domain.session.entity.SessionEntity;
+import com.prography.backend.global.common.StatusCode;
+import com.prography.backend.global.error.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * packageName    : com.prography.backend.domain.attendance.service<br>
+ * fileName       : AttendanceService.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 출결 관련 비즈니스 로직을 처리하는 서비스 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ * 2026-02-24         cod0216             QR 출석용 qrCodeId 저장 지원<br>
+ */
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AttendanceService {
+
+    private final AttendanceRepository attendanceRepository;
+
+    public AttendanceEntity create(SessionEntity session, MemberEntity member, AttendanceStatus status,
+                                   Integer lateMinutes, Long penaltyAmount, String reason, LocalDateTime checkedInAt,
+                                   Long qrCodeId) {
+        AttendanceEntity attendance = AttendanceEntity.builder()
+                .session(session)
+                .member(member)
+                .qrCodeId(qrCodeId)
+                .status(status)
+                .lateMinutes(lateMinutes)
+                .penaltyAmount(penaltyAmount)
+                .reason(reason)
+                .checkedInAt(checkedInAt)
+                .build();
+
+        return attendanceRepository.save(attendance);
+    }
+
+    @Transactional(readOnly = true)
+    public AttendanceEntity getById(Long id) {
+        return attendanceRepository.findById(id)
+                .orElseThrow(() -> new CustomException(StatusCode.ATTENDANCE_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public boolean existsBySessionAndMember(Long sessionId, Long memberId) {
+        return attendanceRepository.existsBySessionIdAndMemberId(sessionId, memberId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<AttendanceEntity> getBySessionId(Long sessionId) {
+        return attendanceRepository.findBySessionIdOrderByCreatedAtAsc(sessionId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<AttendanceEntity> getByMemberId(Long memberId) {
+        return attendanceRepository.findByMemberIdOrderByCreatedAtAsc(memberId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<AttendanceEntity> getByMemberIds(Collection<Long> memberIds) {
+        if (memberIds == null || memberIds.isEmpty()) {
+            return List.of();
+        }
+        return attendanceRepository.findByMemberIdIn(memberIds);
+    }
+}

--- a/src/main/java/com/prography/backend/domain/attendance/service/MemberAttendanceFacadeService.java
+++ b/src/main/java/com/prography/backend/domain/attendance/service/MemberAttendanceFacadeService.java
@@ -1,0 +1,184 @@
+package com.prography.backend.domain.attendance.service;
+
+import com.prography.backend.domain.attendance.dto.request.MemberAttendanceCheckInRequest;
+import com.prography.backend.domain.attendance.dto.response.AttendanceResponse;
+import com.prography.backend.domain.attendance.dto.response.MemberAttendanceResponse;
+import com.prography.backend.domain.attendance.dto.response.MemberAttendanceSummaryResponse;
+import com.prography.backend.domain.attendance.entity.AttendanceEntity;
+import com.prography.backend.domain.attendance.entity.AttendanceStatus;
+import com.prography.backend.domain.attendance.mapper.AttendanceMapper;
+import com.prography.backend.domain.cohort.entity.CohortEntity;
+import com.prography.backend.domain.cohort.service.CohortService;
+import com.prography.backend.domain.cohortmember.entity.CohortMemberEntity;
+import com.prography.backend.domain.cohortmember.service.CohortMemberService;
+import com.prography.backend.domain.deposit.service.DepositHistoryService;
+import com.prography.backend.domain.member.entity.MemberEntity;
+import com.prography.backend.domain.member.entity.MemberStatus;
+import com.prography.backend.domain.member.service.MemberService;
+import com.prography.backend.domain.qrcode.entity.QrCodeEntity;
+import com.prography.backend.domain.qrcode.service.QrCodeService;
+import com.prography.backend.domain.session.entity.SessionEntity;
+import com.prography.backend.domain.session.entity.SessionStatus;
+import com.prography.backend.domain.session.service.SessionService;
+import com.prography.backend.global.common.PolicyConstants;
+import com.prography.backend.global.common.StatusCode;
+import com.prography.backend.global.error.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * packageName    : com.prography.backend.domain.attendance.service<br>
+ * fileName       : MemberAttendanceFacadeService.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 회원 출결 API를 위한 파사드 서비스 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberAttendanceFacadeService {
+
+    private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
+
+    private final AttendanceService attendanceService;
+    private final AttendanceMapper attendanceMapper;
+    private final SessionService sessionService;
+    private final MemberService memberService;
+    private final CohortService cohortService;
+    private final CohortMemberService cohortMemberService;
+    private final DepositHistoryService depositHistoryService;
+    private final QrCodeService qrCodeService;
+
+    public AttendanceResponse checkIn(MemberAttendanceCheckInRequest request) {
+        QrCodeEntity qrCode = qrCodeService.getByHashValue(request.getHashValue());
+        validateQrNotExpired(qrCode);
+
+        SessionEntity session = sessionService.getById(qrCode.getSession().getId());
+        if (session.getStatus() != SessionStatus.IN_PROGRESS) {
+            throw new CustomException(StatusCode.SESSION_NOT_IN_PROGRESS);
+        }
+
+        MemberEntity member = memberService.getById(request.getMemberId());
+        if (member.getStatus() == MemberStatus.WITHDRAWN) {
+            throw new CustomException(StatusCode.MEMBER_WITHDRAWN);
+        }
+
+        if (attendanceService.existsBySessionAndMember(session.getId(), member.getId())) {
+            throw new CustomException(StatusCode.ATTENDANCE_ALREADY_CHECKED);
+        }
+
+        CohortMemberEntity cohortMember = getCurrentCohortMember(member.getId());
+
+        LocalDateTime now = LocalDateTime.now(KOREA_ZONE);
+        LocalDateTime sessionStart = LocalDateTime.of(session.getDate(), session.getTime());
+        AttendanceStatus status = now.isAfter(sessionStart) ? AttendanceStatus.LATE : AttendanceStatus.PRESENT;
+        Integer lateMinutes = status == AttendanceStatus.LATE ? (int) Math.max(0, Duration.between(sessionStart, now).toMinutes()) : null;
+        long penaltyAmount = calculatePenalty(status, lateMinutes);
+
+        AttendanceEntity attendance = attendanceService.create(
+                session,
+                member,
+                status,
+                lateMinutes,
+                penaltyAmount,
+                null,
+                now,
+                qrCode.getId()
+        );
+
+        if (penaltyAmount > 0) {
+            applyPenalty(cohortMember, penaltyAmount, attendance.getId(), "QR 출석 - LATE 패널티 " + penaltyAmount + "원");
+        }
+
+        return attendanceMapper.toResponse(attendance);
+    }
+
+    @Transactional(readOnly = true)
+    public List<MemberAttendanceResponse> getAttendances(Long memberId) {
+        memberService.getById(memberId);
+        return attendanceService.getByMemberId(memberId).stream()
+                .map(attendanceMapper::toMemberResponse)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public MemberAttendanceSummaryResponse getAttendanceSummary(Long memberId) {
+        memberService.getById(memberId);
+        List<AttendanceEntity> attendances = attendanceService.getByMemberId(memberId);
+
+        int present = countStatus(attendances, AttendanceStatus.PRESENT);
+        int absent = countStatus(attendances, AttendanceStatus.ABSENT);
+        int late = countStatus(attendances, AttendanceStatus.LATE);
+        int excused = countStatus(attendances, AttendanceStatus.EXCUSED);
+        long totalPenalty = attendances.stream()
+                .mapToLong(AttendanceEntity::getPenaltyAmount)
+                .sum();
+
+        Long deposit = getCurrentCohortMemberOptional(memberId)
+                .map(CohortMemberEntity::getDeposit)
+                .orElse(null);
+
+        return MemberAttendanceSummaryResponse.builder()
+                .memberId(memberId)
+                .present(present)
+                .absent(absent)
+                .late(late)
+                .excused(excused)
+                .totalPenalty(totalPenalty)
+                .deposit(deposit)
+                .build();
+    }
+
+    private void validateQrNotExpired(QrCodeEntity qrCode) {
+        LocalDateTime now = LocalDateTime.now(KOREA_ZONE);
+        if (qrCode.getExpiresAt().isBefore(now)) {
+            throw new CustomException(StatusCode.QR_EXPIRED);
+        }
+    }
+
+    private CohortMemberEntity getCurrentCohortMember(Long memberId) {
+        CohortEntity cohort = cohortService.getByGeneration(PolicyConstants.CURRENT_GENERATION);
+        return cohortMemberService.findByMemberAndCohort(memberId, cohort.getId())
+                .orElseThrow(() -> new CustomException(StatusCode.COHORT_MEMBER_NOT_FOUND));
+    }
+
+    private Optional<CohortMemberEntity> getCurrentCohortMemberOptional(Long memberId) {
+        CohortEntity cohort = cohortService.getByGeneration(PolicyConstants.CURRENT_GENERATION);
+        return cohortMemberService.findByMemberAndCohort(memberId, cohort.getId());
+    }
+
+    private long calculatePenalty(AttendanceStatus status, Integer lateMinutes) {
+        return switch (status) {
+            case PRESENT, EXCUSED -> 0;
+            case ABSENT -> PolicyConstants.PENALTY_ABSENT;
+            case LATE -> Math.min((long) lateMinutes * PolicyConstants.PENALTY_LATE_PER_MINUTE, PolicyConstants.PENALTY_MAX);
+        };
+    }
+
+    private void applyPenalty(CohortMemberEntity cohortMember, long penaltyAmount, Long attendanceId, String description) {
+        if (cohortMember.getDeposit() < penaltyAmount) {
+            throw new CustomException(StatusCode.DEPOSIT_INSUFFICIENT);
+        }
+
+        long newDeposit = cohortMember.getDeposit() - penaltyAmount;
+        cohortMember.updateDeposit(newDeposit);
+        depositHistoryService.createPenalty(cohortMember, penaltyAmount, attendanceId, description);
+    }
+
+    private int countStatus(List<AttendanceEntity> attendances, AttendanceStatus status) {
+        return (int) attendances.stream()
+                .filter(attendance -> attendance.getStatus() == status)
+                .count();
+    }
+}

--- a/src/main/java/com/prography/backend/domain/member/controller/MemberController.java
+++ b/src/main/java/com/prography/backend/domain/member/controller/MemberController.java
@@ -1,9 +1,9 @@
 package com.prography.backend.domain.member.controller;
 
+import com.prography.backend.domain.attendance.dto.response.MemberAttendanceSummaryResponse;
+import com.prography.backend.domain.attendance.service.MemberAttendanceFacadeService;
 import com.prography.backend.domain.member.dto.response.MemberResponse;
-import com.prography.backend.domain.member.entity.MemberEntity;
-import com.prography.backend.domain.member.mapper.MemberMapper;
-import com.prography.backend.domain.member.service.MemberService;
+import com.prography.backend.domain.member.service.MemberFacadeService;
 import com.prography.backend.global.response.ApiResponse;
 import com.prography.backend.global.util.ResponseUtility;
 import lombok.RequiredArgsConstructor;
@@ -23,18 +23,24 @@ import org.springframework.web.bind.annotation.RestController;
  * DATE              AUTHOR             NOTE<br>
  * -----------------------------------------------------------<br>
  * 2026-02-24         cod0216             최초생성<br>
+ * 2026-02-24         cod0216             회원 조회 응답 매핑 파사드 위임<br>
+ * 2026-02-24         cod0216             출결 요약 조회 엔드포인트 추가<br>
  */
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/members")
 public class MemberController {
 
-    private final MemberService memberService;
-    private final MemberMapper memberMapper;
+    private final MemberFacadeService memberFacadeService;
+    private final MemberAttendanceFacadeService memberAttendanceFacadeService;
 
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponse<MemberResponse>> getMember(@PathVariable Long id) {
-        MemberEntity member = memberService.getById(id);
-        return ResponseUtility.success(memberMapper.toMemberResponse(member));
+        return ResponseUtility.success(memberFacadeService.getMember(id));
+    }
+
+    @GetMapping("/{id}/attendance-summary")
+    public ResponseEntity<ApiResponse<MemberAttendanceSummaryResponse>> getAttendanceSummary(@PathVariable Long id) {
+        return ResponseUtility.success(memberAttendanceFacadeService.getAttendanceSummary(id));
     }
 }

--- a/src/main/java/com/prography/backend/domain/member/service/MemberFacadeService.java
+++ b/src/main/java/com/prography/backend/domain/member/service/MemberFacadeService.java
@@ -1,0 +1,33 @@
+package com.prography.backend.domain.member.service;
+
+import com.prography.backend.domain.member.dto.response.MemberResponse;
+import com.prography.backend.domain.member.entity.MemberEntity;
+import com.prography.backend.domain.member.mapper.MemberMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * packageName    : com.prography.backend.domain.member.service<br>
+ * fileName       : MemberFacadeService.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-25<br>
+ * description    : 회원 조회 응답 매핑을 처리하는 파사드 서비스 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-25         cod0216             최초생성<br>
+ */
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberFacadeService {
+
+    private final MemberService memberService;
+    private final MemberMapper memberMapper;
+
+    public MemberResponse getMember(Long memberId) {
+        MemberEntity member = memberService.getById(memberId);
+        return memberMapper.toMemberResponse(member);
+    }
+}

--- a/src/main/java/com/prography/backend/domain/qrcode/entity/QrCodeEntity.java
+++ b/src/main/java/com/prography/backend/domain/qrcode/entity/QrCodeEntity.java
@@ -1,0 +1,47 @@
+package com.prography.backend.domain.qrcode.entity;
+
+import com.prography.backend.domain.session.entity.SessionEntity;
+import com.prography.backend.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * packageName    : com.prography.backend.domain.qrcode.entity<br>
+ * fileName       : QrCodeEntity.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : QR 코드 엔티티 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Entity
+@Getter
+@Builder
+@Table(name = "tb_qrcode")
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class QrCodeEntity extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "session_id", nullable = false)
+    private SessionEntity session;
+
+    @Column(name = "hash_value", nullable = false, unique = true, length = 100)
+    private String hashValue;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+}

--- a/src/main/java/com/prography/backend/domain/qrcode/repository/QrCodeRepository.java
+++ b/src/main/java/com/prography/backend/domain/qrcode/repository/QrCodeRepository.java
@@ -1,0 +1,21 @@
+package com.prography.backend.domain.qrcode.repository;
+
+import com.prography.backend.domain.qrcode.entity.QrCodeEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+/**
+ * packageName    : com.prography.backend.domain.qrcode.repository<br>
+ * fileName       : QrCodeRepository.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : QR 코드 레포지토리 인터페이스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+public interface QrCodeRepository extends JpaRepository<QrCodeEntity, Long> {
+    Optional<QrCodeEntity> findByHashValue(String hashValue);
+}

--- a/src/main/java/com/prography/backend/domain/qrcode/service/QrCodeService.java
+++ b/src/main/java/com/prography/backend/domain/qrcode/service/QrCodeService.java
@@ -1,0 +1,33 @@
+package com.prography.backend.domain.qrcode.service;
+
+import com.prography.backend.domain.qrcode.entity.QrCodeEntity;
+import com.prography.backend.domain.qrcode.repository.QrCodeRepository;
+import com.prography.backend.global.common.StatusCode;
+import com.prography.backend.global.error.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * packageName    : com.prography.backend.domain.qrcode.service<br>
+ * fileName       : QrCodeService.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : QR 코드 조회 관련 비즈니스 로직을 처리하는 서비스 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class QrCodeService {
+
+    private final QrCodeRepository qrCodeRepository;
+
+    public QrCodeEntity getByHashValue(String hashValue) {
+        return qrCodeRepository.findByHashValue(hashValue)
+                .orElseThrow(() -> new CustomException(StatusCode.QR_INVALID));
+    }
+}

--- a/src/test/java/com/prography/backend/domain/attendance/service/MemberAttendanceFacadeServiceTest.java
+++ b/src/test/java/com/prography/backend/domain/attendance/service/MemberAttendanceFacadeServiceTest.java
@@ -1,0 +1,185 @@
+package com.prography.backend.domain.attendance.service;
+
+import com.prography.backend.domain.attendance.dto.request.MemberAttendanceCheckInRequest;
+import com.prography.backend.domain.attendance.dto.response.AttendanceResponse;
+import com.prography.backend.domain.attendance.dto.response.MemberAttendanceResponse;
+import com.prography.backend.domain.attendance.dto.response.MemberAttendanceSummaryResponse;
+import com.prography.backend.domain.attendance.entity.AttendanceStatus;
+import com.prography.backend.domain.cohort.entity.CohortEntity;
+import com.prography.backend.domain.cohort.repository.CohortRepository;
+import com.prography.backend.domain.cohortmember.entity.CohortMemberEntity;
+import com.prography.backend.domain.cohortmember.service.CohortMemberService;
+import com.prography.backend.domain.deposit.entity.DepositHistoryEntity;
+import com.prography.backend.domain.deposit.entity.DepositType;
+import com.prography.backend.domain.deposit.repository.DepositHistoryRepository;
+import com.prography.backend.domain.member.entity.MemberEntity;
+import com.prography.backend.domain.member.entity.MemberRole;
+import com.prography.backend.domain.member.service.MemberService;
+import com.prography.backend.domain.qrcode.entity.QrCodeEntity;
+import com.prography.backend.domain.qrcode.repository.QrCodeRepository;
+import com.prography.backend.domain.session.entity.SessionEntity;
+import com.prography.backend.domain.session.entity.SessionStatus;
+import com.prography.backend.domain.session.repository.SessionRepository;
+import com.prography.backend.global.common.PolicyConstants;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * packageName    : com.prography.backend.domain.attendance.service<br>
+ * fileName       : MemberAttendanceFacadeServiceTest.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 회원 출결 파사드 서비스 테스트 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@SpringBootTest
+@Transactional
+class MemberAttendanceFacadeServiceTest {
+
+    private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
+
+    @Autowired
+    private MemberAttendanceFacadeService memberAttendanceFacadeService;
+
+    @Autowired
+    private AttendanceService attendanceService;
+
+    @Autowired
+    private CohortRepository cohortRepository;
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private CohortMemberService cohortMemberService;
+
+    @Autowired
+    private SessionRepository sessionRepository;
+
+    @Autowired
+    private QrCodeRepository qrCodeRepository;
+
+    @Autowired
+    private DepositHistoryRepository depositHistoryRepository;
+
+    @Test
+    void checkIn_late_createsPenaltyHistory() {
+        // Given
+        CohortMemberEntity cohortMember = createCohortMember("late-user", PolicyConstants.INITIAL_DEPOSIT);
+        LocalDateTime now = LocalDateTime.now(KOREA_ZONE);
+        SessionEntity session = createSession(cohortMember.getCohort(), now.toLocalDate(), now.minusMinutes(10).toLocalTime(), SessionStatus.IN_PROGRESS);
+        QrCodeEntity qrCode = qrCodeRepository.save(QrCodeEntity.builder()
+                .session(session)
+                .hashValue("hash-late")
+                .expiresAt(now.plusHours(1))
+                .build());
+
+        MemberAttendanceCheckInRequest request = new MemberAttendanceCheckInRequest();
+        setField(request, "hashValue", qrCode.getHashValue());
+        setField(request, "memberId", cohortMember.getMember().getId());
+
+        // When
+        AttendanceResponse response = memberAttendanceFacadeService.checkIn(request);
+
+        // Then
+        assertThat(response.getStatus()).isEqualTo(AttendanceStatus.LATE);
+        assertThat(response.getPenaltyAmount()).isPositive();
+
+        CohortMemberEntity updated = cohortMemberService.getById(cohortMember.getId());
+        assertThat(updated.getDeposit()).isEqualTo(PolicyConstants.INITIAL_DEPOSIT - response.getPenaltyAmount());
+
+        List<DepositHistoryEntity> histories = depositHistoryRepository.findByCohortMemberIdOrderByCreatedAtAsc(cohortMember.getId());
+        assertThat(histories).hasSize(1);
+        assertThat(histories.get(0).getType()).isEqualTo(DepositType.PENALTY);
+        assertThat(histories.get(0).getAttendanceId()).isEqualTo(response.getId());
+    }
+
+    @Test
+    void getAttendances_returnsSessionTitle() {
+        // Given
+        CohortMemberEntity cohortMember = createCohortMember("list-user", 90_000L);
+        SessionEntity session = createSession(cohortMember.getCohort(), LocalDate.of(2026, 2, 24), LocalTime.of(10, 0), SessionStatus.SCHEDULED);
+        attendanceService.create(session, cohortMember.getMember(), AttendanceStatus.PRESENT, null, 0L, null, null, null);
+
+        // When
+        List<MemberAttendanceResponse> responses = memberAttendanceFacadeService.getAttendances(cohortMember.getMember().getId());
+
+        // Then
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).getSessionTitle()).isEqualTo(session.getTitle());
+    }
+
+    @Test
+    void getAttendanceSummary_countsAndDeposit() {
+        // Given
+        CohortMemberEntity cohortMember = createCohortMember("summary-user", 85_000L);
+        SessionEntity session1 = createSession(cohortMember.getCohort(), LocalDate.of(2026, 2, 24), LocalTime.of(10, 0), SessionStatus.SCHEDULED);
+        SessionEntity session2 = createSession(cohortMember.getCohort(), LocalDate.of(2026, 2, 25), LocalTime.of(10, 0), SessionStatus.SCHEDULED);
+        SessionEntity session3 = createSession(cohortMember.getCohort(), LocalDate.of(2026, 2, 26), LocalTime.of(10, 0), SessionStatus.SCHEDULED);
+
+        attendanceService.create(session1, cohortMember.getMember(), AttendanceStatus.PRESENT, null, 0L, null, null, null);
+        attendanceService.create(session2, cohortMember.getMember(), AttendanceStatus.ABSENT, null, PolicyConstants.PENALTY_ABSENT, null, null, null);
+        attendanceService.create(session3, cohortMember.getMember(), AttendanceStatus.LATE, 5, 2_500L, null, null, null);
+
+        // When
+        MemberAttendanceSummaryResponse response = memberAttendanceFacadeService.getAttendanceSummary(cohortMember.getMember().getId());
+
+        // Then
+        assertThat(response.getPresent()).isEqualTo(1);
+        assertThat(response.getAbsent()).isEqualTo(1);
+        assertThat(response.getLate()).isEqualTo(1);
+        assertThat(response.getExcused()).isZero();
+        assertThat(response.getTotalPenalty()).isEqualTo(PolicyConstants.PENALTY_ABSENT + 2_500L);
+        assertThat(response.getDeposit()).isEqualTo(85_000L);
+    }
+
+    private CohortMemberEntity createCohortMember(String loginId, long deposit) {
+        CohortEntity cohort = cohortRepository.save(CohortEntity.builder().generation(PolicyConstants.CURRENT_GENERATION).name("11기").build());
+        MemberEntity member = memberService.createMember(
+                loginId,
+                passwordEncoder.encode("password123"),
+                "홍길동",
+                "010-1234-5678",
+                MemberRole.MEMBER
+        );
+        return cohortMemberService.create(member, cohort, null, null, deposit);
+    }
+
+    private SessionEntity createSession(CohortEntity cohort, LocalDate date, LocalTime time, SessionStatus status) {
+        return sessionRepository.save(SessionEntity.builder()
+                .cohort(cohort)
+                .title("정기 모임")
+                .date(date)
+                .time(time)
+                .location("강남")
+                .status(status)
+                .build());
+    }
+
+    private void setField(Object target, String fieldName, Object value) {
+        try {
+            java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}


### PR DESCRIPTION
  ## #️⃣ 관련 이슈
- #9 

  ## 📝 작업 내용
  - QR 출석 체크 API 추가 (`POST /api/v1/attendances`)
  - 내 출결 기록 조회 API 추가 (`GET /api/v1/attendances?memberId=`)
  - 내 출결 요약 조회 API 추가 (`GET /api/v1/members/{id}/attendance-summary`)
  - QR 도메인 추가 (Entity/Repository/Service)
  - 출결 매퍼/서비스 보강 (회원 응답 매핑, qrCodeId 저장)

  ## ✅ 테스트 결과
  - [x] ./gradlew test --tests "com.prography.backend.domain.attendance.service.MemberAttendanceFacadeServiceTest"