### PR TITLE
feat: add admin session and qr apis

### DIFF
--- a/src/main/java/com/prography/backend/domain/attendance/repository/AttendanceRepository.java
+++ b/src/main/java/com/prography/backend/domain/attendance/repository/AttendanceRepository.java
@@ -16,11 +16,14 @@ import java.util.List;
  * DATE              AUTHOR             NOTE<br>
  * -----------------------------------------------------------<br>
  * 2026-02-24         cod0216             최초생성<br>
+ * 2026-02-24         cod0216             일정별 출결 조회 추가<br>
  */
 public interface AttendanceRepository extends JpaRepository<AttendanceEntity, Long> {
     boolean existsBySessionIdAndMemberId(Long sessionId, Long memberId);
 
     List<AttendanceEntity> findBySessionIdOrderByCreatedAtAsc(Long sessionId);
+
+    List<AttendanceEntity> findBySessionIdIn(Collection<Long> sessionIds);
 
     List<AttendanceEntity> findByMemberIdOrderByCreatedAtAsc(Long memberId);
 

--- a/src/main/java/com/prography/backend/domain/attendance/service/AttendanceService.java
+++ b/src/main/java/com/prography/backend/domain/attendance/service/AttendanceService.java
@@ -26,6 +26,7 @@ import java.util.List;
  * -----------------------------------------------------------<br>
  * 2026-02-24         cod0216             최초생성<br>
  * 2026-02-24         cod0216             QR 출석용 qrCodeId 저장 지원<br>
+ * 2026-02-24         cod0216             일정 다건 조회 기능 추가<br>
  */
 @Service
 @Transactional
@@ -65,6 +66,14 @@ public class AttendanceService {
     @Transactional(readOnly = true)
     public List<AttendanceEntity> getBySessionId(Long sessionId) {
         return attendanceRepository.findBySessionIdOrderByCreatedAtAsc(sessionId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<AttendanceEntity> getBySessionIds(Collection<Long> sessionIds) {
+        if (sessionIds == null || sessionIds.isEmpty()) {
+            return List.of();
+        }
+        return attendanceRepository.findBySessionIdIn(sessionIds);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/prography/backend/domain/qrcode/controller/AdminQrCodeController.java
+++ b/src/main/java/com/prography/backend/domain/qrcode/controller/AdminQrCodeController.java
@@ -1,0 +1,42 @@
+package com.prography.backend.domain.qrcode.controller;
+
+import com.prography.backend.domain.qrcode.dto.response.QrCodeResponse;
+import com.prography.backend.domain.qrcode.service.AdminQrCodeFacadeService;
+import com.prography.backend.global.response.ApiResponse;
+import com.prography.backend.global.util.ResponseUtility;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * packageName    : com.prography.backend.domain.qrcode.controller<br>
+ * fileName       : AdminQrCodeController.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-25<br>
+ * description    : 관리자 QR 코드 API를 처리하는 컨트롤러 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-25         cod0216             최초생성<br>
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin")
+public class AdminQrCodeController {
+
+    private final AdminQrCodeFacadeService adminQrCodeFacadeService;
+
+    @PostMapping("/sessions/{sessionId}/qrcodes")
+    public ResponseEntity<ApiResponse<QrCodeResponse>> createQrCode(@PathVariable Long sessionId) {
+        return ResponseUtility.created(adminQrCodeFacadeService.createQrCode(sessionId));
+    }
+
+    @PutMapping("/qrcodes/{qrCodeId}")
+    public ResponseEntity<ApiResponse<QrCodeResponse>> renewQrCode(@PathVariable Long qrCodeId) {
+        return ResponseUtility.success(adminQrCodeFacadeService.renewQrCode(qrCodeId));
+    }
+}

--- a/src/main/java/com/prography/backend/domain/qrcode/dto/response/QrCodeResponse.java
+++ b/src/main/java/com/prography/backend/domain/qrcode/dto/response/QrCodeResponse.java
@@ -1,0 +1,27 @@
+package com.prography.backend.domain.qrcode.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * packageName    : com.prography.backend.domain.qrcode.dto.response<br>
+ * fileName       : QrCodeResponse.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : QR 코드 응답 DTO 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Getter
+@Builder
+public class QrCodeResponse {
+    private Long id;
+    private Long sessionId;
+    private String hashValue;
+    private LocalDateTime createdAt;
+    private LocalDateTime expiresAt;
+}

--- a/src/main/java/com/prography/backend/domain/qrcode/entity/QrCodeEntity.java
+++ b/src/main/java/com/prography/backend/domain/qrcode/entity/QrCodeEntity.java
@@ -26,6 +26,7 @@ import java.time.LocalDateTime;
  * DATE              AUTHOR             NOTE<br>
  * -----------------------------------------------------------<br>
  * 2026-02-24         cod0216             최초생성<br>
+ * 2026-02-24         cod0216             만료 시각 갱신 메서드 추가<br>
  */
 @Entity
 @Getter
@@ -44,4 +45,8 @@ public class QrCodeEntity extends BaseEntity {
 
     @Column(name = "expires_at", nullable = false)
     private LocalDateTime expiresAt;
+
+    public void updateExpiresAt(LocalDateTime expiresAt) {
+        this.expiresAt = expiresAt;
+    }
 }

--- a/src/main/java/com/prography/backend/domain/qrcode/mapper/QrCodeMapper.java
+++ b/src/main/java/com/prography/backend/domain/qrcode/mapper/QrCodeMapper.java
@@ -1,0 +1,34 @@
+package com.prography.backend.domain.qrcode.mapper;
+
+import com.prography.backend.domain.qrcode.dto.response.QrCodeResponse;
+import com.prography.backend.domain.qrcode.entity.QrCodeEntity;
+import org.springframework.stereotype.Component;
+
+/**
+ * packageName    : com.prography.backend.domain.qrcode.mapper<br>
+ * fileName       : QrCodeMapper.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : QR 코드 응답 매핑을 담당하는 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Component
+public class QrCodeMapper {
+
+    public QrCodeResponse toResponse(QrCodeEntity qrCode) {
+        if (qrCode == null) {
+            return null;
+        }
+
+        return QrCodeResponse.builder()
+                .id(qrCode.getId())
+                .sessionId(qrCode.getSession().getId())
+                .hashValue(qrCode.getHashValue())
+                .createdAt(qrCode.getCreatedAt())
+                .expiresAt(qrCode.getExpiresAt())
+                .build();
+    }
+}

--- a/src/main/java/com/prography/backend/domain/qrcode/repository/QrCodeRepository.java
+++ b/src/main/java/com/prography/backend/domain/qrcode/repository/QrCodeRepository.java
@@ -3,6 +3,9 @@ package com.prography.backend.domain.qrcode.repository;
 import com.prography.backend.domain.qrcode.entity.QrCodeEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -15,7 +18,10 @@ import java.util.Optional;
  * DATE              AUTHOR             NOTE<br>
  * -----------------------------------------------------------<br>
  * 2026-02-24         cod0216             최초생성<br>
+ * 2026-02-24         cod0216             활성 QR 조회 메서드 추가<br>
  */
 public interface QrCodeRepository extends JpaRepository<QrCodeEntity, Long> {
     Optional<QrCodeEntity> findByHashValue(String hashValue);
+    Optional<QrCodeEntity> findFirstBySessionIdAndExpiresAtAfter(Long sessionId, LocalDateTime now);
+    List<QrCodeEntity> findBySessionIdInAndExpiresAtAfter(Collection<Long> sessionIds, LocalDateTime now);
 }

--- a/src/main/java/com/prography/backend/domain/qrcode/service/AdminQrCodeFacadeService.java
+++ b/src/main/java/com/prography/backend/domain/qrcode/service/AdminQrCodeFacadeService.java
@@ -1,0 +1,68 @@
+package com.prography.backend.domain.qrcode.service;
+
+import com.prography.backend.domain.qrcode.dto.response.QrCodeResponse;
+import com.prography.backend.domain.qrcode.entity.QrCodeEntity;
+import com.prography.backend.domain.qrcode.mapper.QrCodeMapper;
+import com.prography.backend.domain.session.entity.SessionEntity;
+import com.prography.backend.domain.session.service.SessionService;
+import com.prography.backend.global.common.PolicyConstants;
+import com.prography.backend.global.common.StatusCode;
+import com.prography.backend.global.error.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+/**
+ * packageName    : com.prography.backend.domain.qrcode.service<br>
+ * fileName       : AdminQrCodeFacadeService.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-25<br>
+ * description    : 관리자 QR 코드 API를 위한 파사드 서비스 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-25         cod0216             최초생성<br>
+ */
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AdminQrCodeFacadeService {
+
+    private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
+
+    private final SessionService sessionService;
+    private final QrCodeService qrCodeService;
+    private final QrCodeMapper qrCodeMapper;
+
+    public QrCodeResponse createQrCode(Long sessionId) {
+        SessionEntity session = sessionService.getById(sessionId);
+
+        if (qrCodeService.findActiveBySessionId(sessionId, now()).isPresent()) {
+            throw new CustomException(StatusCode.QR_ALREADY_ACTIVE);
+        }
+
+        QrCodeEntity created = qrCodeService.create(session, nextExpiresAt());
+        return qrCodeMapper.toResponse(created);
+    }
+
+    public QrCodeResponse renewQrCode(Long qrCodeId) {
+        QrCodeEntity existing = qrCodeService.getById(qrCodeId);
+
+        LocalDateTime now = now();
+        qrCodeService.expire(existing, now);
+
+        QrCodeEntity created = qrCodeService.create(existing.getSession(), now.plusHours(PolicyConstants.QR_EXPIRE_HOURS));
+        return qrCodeMapper.toResponse(created);
+    }
+
+    private LocalDateTime nextExpiresAt() {
+        return now().plusHours(PolicyConstants.QR_EXPIRE_HOURS);
+    }
+
+    private LocalDateTime now() {
+        return LocalDateTime.now(KOREA_ZONE);
+    }
+}

--- a/src/main/java/com/prography/backend/domain/qrcode/service/QrCodeService.java
+++ b/src/main/java/com/prography/backend/domain/qrcode/service/QrCodeService.java
@@ -2,11 +2,18 @@ package com.prography.backend.domain.qrcode.service;
 
 import com.prography.backend.domain.qrcode.entity.QrCodeEntity;
 import com.prography.backend.domain.qrcode.repository.QrCodeRepository;
+import com.prography.backend.domain.session.entity.SessionEntity;
 import com.prography.backend.global.common.StatusCode;
 import com.prography.backend.global.error.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 /**
  * packageName    : com.prography.backend.domain.qrcode.service<br>
@@ -18,16 +25,48 @@ import org.springframework.transaction.annotation.Transactional;
  * DATE              AUTHOR             NOTE<br>
  * -----------------------------------------------------------<br>
  * 2026-02-24         cod0216             최초생성<br>
+ * 2026-02-24         cod0216             QR 생성 및 활성 조회 기능 추가<br>
  */
 @Service
-@Transactional(readOnly = true)
+@Transactional
 @RequiredArgsConstructor
 public class QrCodeService {
 
     private final QrCodeRepository qrCodeRepository;
 
+    @Transactional(readOnly = true)
     public QrCodeEntity getByHashValue(String hashValue) {
         return qrCodeRepository.findByHashValue(hashValue)
                 .orElseThrow(() -> new CustomException(StatusCode.QR_INVALID));
+    }
+
+    @Transactional(readOnly = true)
+    public QrCodeEntity getById(Long id) {
+        return qrCodeRepository.findById(id)
+                .orElseThrow(() -> new CustomException(StatusCode.QR_NOT_FOUND));
+    }
+
+    public QrCodeEntity create(SessionEntity session, LocalDateTime expiresAt) {
+        QrCodeEntity qrCode = QrCodeEntity.builder()
+                .session(session)
+                .hashValue(UUID.randomUUID().toString())
+                .expiresAt(expiresAt)
+                .build();
+        return qrCodeRepository.save(qrCode);
+    }
+
+    public Optional<QrCodeEntity> findActiveBySessionId(Long sessionId, LocalDateTime now) {
+        return qrCodeRepository.findFirstBySessionIdAndExpiresAtAfter(sessionId, now);
+    }
+
+    public List<QrCodeEntity> findActiveBySessionIds(Collection<Long> sessionIds, LocalDateTime now) {
+        if (sessionIds == null || sessionIds.isEmpty()) {
+            return List.of();
+        }
+        return qrCodeRepository.findBySessionIdInAndExpiresAtAfter(sessionIds, now);
+    }
+
+    public void expire(QrCodeEntity qrCode, LocalDateTime now) {
+        qrCode.updateExpiresAt(now);
     }
 }

--- a/src/main/java/com/prography/backend/domain/session/controller/AdminSessionController.java
+++ b/src/main/java/com/prography/backend/domain/session/controller/AdminSessionController.java
@@ -1,0 +1,70 @@
+package com.prography.backend.domain.session.controller;
+
+import com.prography.backend.domain.session.dto.request.AdminSessionCreateRequest;
+import com.prography.backend.domain.session.dto.request.AdminSessionUpdateRequest;
+import com.prography.backend.domain.session.dto.response.AdminSessionResponse;
+import com.prography.backend.domain.session.entity.SessionStatus;
+import com.prography.backend.domain.session.service.AdminSessionFacadeService;
+import com.prography.backend.global.response.ApiResponse;
+import com.prography.backend.global.util.ResponseUtility;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * packageName    : com.prography.backend.domain.session.controller<br>
+ * fileName       : AdminSessionController.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 관리자 일정 API를 처리하는 컨트롤러 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/sessions")
+public class AdminSessionController {
+
+    private final AdminSessionFacadeService adminSessionFacadeService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<AdminSessionResponse>>> getSessions(
+            @RequestParam(required = false) LocalDate dateFrom,
+            @RequestParam(required = false) LocalDate dateTo,
+            @RequestParam(required = false) SessionStatus status
+    ) {
+        return ResponseUtility.success(adminSessionFacadeService.getSessions(dateFrom, dateTo, status));
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<AdminSessionResponse>> createSession(@RequestBody @Valid AdminSessionCreateRequest request) {
+        return ResponseUtility.created(adminSessionFacadeService.createSession(request));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiResponse<AdminSessionResponse>> updateSession(
+            @PathVariable Long id,
+            @RequestBody AdminSessionUpdateRequest request
+    ) {
+        return ResponseUtility.success(adminSessionFacadeService.updateSession(id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<AdminSessionResponse>> cancelSession(@PathVariable Long id) {
+        return ResponseUtility.success(adminSessionFacadeService.cancelSession(id));
+    }
+}

--- a/src/main/java/com/prography/backend/domain/session/dto/request/AdminSessionCreateRequest.java
+++ b/src/main/java/com/prography/backend/domain/session/dto/request/AdminSessionCreateRequest.java
@@ -1,0 +1,35 @@
+package com.prography.backend.domain.session.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+/**
+ * packageName    : com.prography.backend.domain.session.dto.request<br>
+ * fileName       : AdminSessionCreateRequest.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 관리자 일정 생성 요청 DTO 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Getter
+public class AdminSessionCreateRequest {
+
+    @NotBlank(message = "title은 필수입니다.")
+    private String title;
+
+    @NotNull(message = "date는 필수입니다.")
+    private LocalDate date;
+
+    @NotNull(message = "time은 필수입니다.")
+    private LocalTime time;
+
+    @NotBlank(message = "location은 필수입니다.")
+    private String location;
+}

--- a/src/main/java/com/prography/backend/domain/session/dto/request/AdminSessionUpdateRequest.java
+++ b/src/main/java/com/prography/backend/domain/session/dto/request/AdminSessionUpdateRequest.java
@@ -1,0 +1,27 @@
+package com.prography.backend.domain.session.dto.request;
+
+import com.prography.backend.domain.session.entity.SessionStatus;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+/**
+ * packageName    : com.prography.backend.domain.session.dto.request<br>
+ * fileName       : AdminSessionUpdateRequest.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 관리자 일정 수정 요청 DTO 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Getter
+public class AdminSessionUpdateRequest {
+    private String title;
+    private LocalDate date;
+    private LocalTime time;
+    private String location;
+    private SessionStatus status;
+}

--- a/src/main/java/com/prography/backend/domain/session/dto/response/AdminSessionResponse.java
+++ b/src/main/java/com/prography/backend/domain/session/dto/response/AdminSessionResponse.java
@@ -1,0 +1,36 @@
+package com.prography.backend.domain.session.dto.response;
+
+import com.prography.backend.domain.session.entity.SessionStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+/**
+ * packageName    : com.prography.backend.domain.session.dto.response<br>
+ * fileName       : AdminSessionResponse.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 관리자 일정 응답 DTO 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Getter
+@Builder
+public class AdminSessionResponse {
+    private Long id;
+    private Long cohortId;
+    private String title;
+    private LocalDate date;
+    private LocalTime time;
+    private String location;
+    private SessionStatus status;
+    private SessionAttendanceSummaryResponse attendanceSummary;
+    private boolean qrActive;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/prography/backend/domain/session/dto/response/SessionAttendanceSummaryResponse.java
+++ b/src/main/java/com/prography/backend/domain/session/dto/response/SessionAttendanceSummaryResponse.java
@@ -1,0 +1,25 @@
+package com.prography.backend.domain.session.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * packageName    : com.prography.backend.domain.session.dto.response<br>
+ * fileName       : SessionAttendanceSummaryResponse.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 일정 출결 요약 응답 DTO 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Getter
+@Builder
+public class SessionAttendanceSummaryResponse {
+    private int present;
+    private int absent;
+    private int late;
+    private int excused;
+    private int total;
+}

--- a/src/main/java/com/prography/backend/domain/session/entity/SessionEntity.java
+++ b/src/main/java/com/prography/backend/domain/session/entity/SessionEntity.java
@@ -29,6 +29,7 @@ import java.time.LocalTime;
  * DATE              AUTHOR             NOTE<br>
  * -----------------------------------------------------------<br>
  * 2026-02-24         cod0216             최초생성<br>
+ * 2026-02-24         cod0216             일정 수정 및 취소 처리 메서드 추가<br>
  */
 @Entity
 @Getter
@@ -57,4 +58,29 @@ public class SessionEntity extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     private SessionStatus status;
+
+    public void updateInfo(String title, LocalDate date, LocalTime time, String location) {
+        if (title != null) {
+            this.title = title;
+        }
+        if (date != null) {
+            this.date = date;
+        }
+        if (time != null) {
+            this.time = time;
+        }
+        if (location != null) {
+            this.location = location;
+        }
+    }
+
+    public void updateStatus(SessionStatus status) {
+        if (status != null) {
+            this.status = status;
+        }
+    }
+
+    public void cancel() {
+        this.status = SessionStatus.CANCELLED;
+    }
 }

--- a/src/main/java/com/prography/backend/domain/session/mapper/SessionMapper.java
+++ b/src/main/java/com/prography/backend/domain/session/mapper/SessionMapper.java
@@ -1,0 +1,41 @@
+package com.prography.backend.domain.session.mapper;
+
+import com.prography.backend.domain.session.dto.response.AdminSessionResponse;
+import com.prography.backend.domain.session.dto.response.SessionAttendanceSummaryResponse;
+import com.prography.backend.domain.session.entity.SessionEntity;
+import org.springframework.stereotype.Component;
+
+/**
+ * packageName    : com.prography.backend.domain.session.mapper<br>
+ * fileName       : SessionMapper.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 일정 응답 매핑을 담당하는 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Component
+public class SessionMapper {
+
+    public AdminSessionResponse toAdminResponse(SessionEntity session, SessionAttendanceSummaryResponse summary, boolean qrActive) {
+        if (session == null) {
+            return null;
+        }
+
+        return AdminSessionResponse.builder()
+                .id(session.getId())
+                .cohortId(session.getCohort().getId())
+                .title(session.getTitle())
+                .date(session.getDate())
+                .time(session.getTime())
+                .location(session.getLocation())
+                .status(session.getStatus())
+                .attendanceSummary(summary)
+                .qrActive(qrActive)
+                .createdAt(session.getCreatedAt())
+                .updatedAt(session.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/prography/backend/domain/session/repository/SessionRepository.java
+++ b/src/main/java/com/prography/backend/domain/session/repository/SessionRepository.java
@@ -3,6 +3,8 @@ package com.prography.backend.domain.session.repository;
 import com.prography.backend.domain.session.entity.SessionEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 /**
  * packageName    : com.prography.backend.domain.session.repository<br>
  * fileName       : SessionRepository.java<br>
@@ -13,6 +15,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
  * DATE              AUTHOR             NOTE<br>
  * -----------------------------------------------------------<br>
  * 2026-02-24         cod0216             최초생성<br>
+ * 2026-02-24         cod0216             기수별 일정 조회 추가<br>
  */
 public interface SessionRepository extends JpaRepository<SessionEntity, Long> {
+    List<SessionEntity> findByCohortIdOrderByDateAscTimeAsc(Long cohortId);
 }

--- a/src/main/java/com/prography/backend/domain/session/service/AdminSessionFacadeService.java
+++ b/src/main/java/com/prography/backend/domain/session/service/AdminSessionFacadeService.java
@@ -1,0 +1,176 @@
+package com.prography.backend.domain.session.service;
+
+import com.prography.backend.domain.attendance.entity.AttendanceEntity;
+import com.prography.backend.domain.attendance.entity.AttendanceStatus;
+import com.prography.backend.domain.attendance.service.AttendanceService;
+import com.prography.backend.domain.cohort.entity.CohortEntity;
+import com.prography.backend.domain.cohort.service.CohortService;
+import com.prography.backend.domain.qrcode.entity.QrCodeEntity;
+import com.prography.backend.domain.qrcode.service.QrCodeService;
+import com.prography.backend.domain.session.dto.request.AdminSessionCreateRequest;
+import com.prography.backend.domain.session.dto.request.AdminSessionUpdateRequest;
+import com.prography.backend.domain.session.dto.response.AdminSessionResponse;
+import com.prography.backend.domain.session.dto.response.SessionAttendanceSummaryResponse;
+import com.prography.backend.domain.session.entity.SessionEntity;
+import com.prography.backend.domain.session.entity.SessionStatus;
+import com.prography.backend.domain.session.mapper.SessionMapper;
+import com.prography.backend.global.common.PolicyConstants;
+import com.prography.backend.global.common.StatusCode;
+import com.prography.backend.global.error.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * packageName    : com.prography.backend.domain.session.service<br>
+ * fileName       : AdminSessionFacadeService.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 관리자 일정 API를 위한 파사드 서비스 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AdminSessionFacadeService {
+
+    private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
+
+    private final SessionService sessionService;
+    private final SessionMapper sessionMapper;
+    private final CohortService cohortService;
+    private final AttendanceService attendanceService;
+    private final QrCodeService qrCodeService;
+
+    @Transactional(readOnly = true)
+    public List<AdminSessionResponse> getSessions(LocalDate dateFrom, LocalDate dateTo, SessionStatus status) {
+        CohortEntity cohort = cohortService.getByGeneration(PolicyConstants.CURRENT_GENERATION);
+        List<SessionEntity> sessions = sessionService.getByCohortId(cohort.getId());
+
+        List<SessionEntity> filtered = sessions.stream()
+                .filter(session -> matchesDateFrom(session, dateFrom))
+                .filter(session -> matchesDateTo(session, dateTo))
+                .filter(session -> status == null || session.getStatus() == status)
+                .toList();
+
+        List<Long> sessionIds = filtered.stream()
+                .map(SessionEntity::getId)
+                .toList();
+
+        Map<Long, List<AttendanceEntity>> attendanceMap = attendanceService.getBySessionIds(sessionIds).stream()
+                .collect(Collectors.groupingBy(attendance -> attendance.getSession().getId()));
+
+        Set<Long> activeQrSessionIds = qrCodeService.findActiveBySessionIds(sessionIds, now())
+                .stream()
+                .map(qrCode -> qrCode.getSession().getId())
+                .collect(Collectors.toSet());
+
+        List<AdminSessionResponse> responses = new ArrayList<>();
+        for (SessionEntity session : filtered) {
+            List<AttendanceEntity> attendances = attendanceMap.getOrDefault(session.getId(), List.of());
+            SessionAttendanceSummaryResponse summary = buildSummary(attendances);
+            boolean qrActive = activeQrSessionIds.contains(session.getId());
+            responses.add(sessionMapper.toAdminResponse(session, summary, qrActive));
+        }
+
+        return responses;
+    }
+
+    public AdminSessionResponse createSession(AdminSessionCreateRequest request) {
+        CohortEntity cohort = cohortService.getByGeneration(PolicyConstants.CURRENT_GENERATION);
+        SessionEntity session = sessionService.create(cohort, request.getTitle(), request.getDate(), request.getTime(), request.getLocation());
+
+        LocalDateTime expiresAt = now().plusHours(PolicyConstants.QR_EXPIRE_HOURS);
+        qrCodeService.create(session, expiresAt);
+
+        SessionAttendanceSummaryResponse summary = buildSummary(List.of());
+        return sessionMapper.toAdminResponse(session, summary, true);
+    }
+
+    public AdminSessionResponse updateSession(Long sessionId, AdminSessionUpdateRequest request) {
+        SessionEntity session = sessionService.getById(sessionId);
+        if (session.getStatus() == SessionStatus.CANCELLED) {
+            throw new CustomException(StatusCode.SESSION_ALREADY_CANCELLED);
+        }
+
+        sessionService.update(session, request.getTitle(), request.getDate(), request.getTime(), request.getLocation(), request.getStatus());
+
+        if (session.getStatus() == SessionStatus.CANCELLED) {
+            expireActiveQr(session.getId());
+        }
+
+        SessionAttendanceSummaryResponse summary = buildSummary(attendanceService.getBySessionId(session.getId()));
+        boolean qrActive = qrCodeService.findActiveBySessionId(session.getId(), now()).isPresent();
+        return sessionMapper.toAdminResponse(session, summary, qrActive);
+    }
+
+    public AdminSessionResponse cancelSession(Long sessionId) {
+        SessionEntity session = sessionService.getById(sessionId);
+        if (session.getStatus() == SessionStatus.CANCELLED) {
+            throw new CustomException(StatusCode.SESSION_ALREADY_CANCELLED);
+        }
+
+        sessionService.cancel(session);
+        expireActiveQr(session.getId());
+
+        SessionAttendanceSummaryResponse summary = buildSummary(attendanceService.getBySessionId(session.getId()));
+        return sessionMapper.toAdminResponse(session, summary, false);
+    }
+
+    private void expireActiveQr(Long sessionId) {
+        qrCodeService.findActiveBySessionId(sessionId, now())
+                .ifPresent(qrCode -> qrCodeService.expire(qrCode, now()));
+    }
+
+    private SessionAttendanceSummaryResponse buildSummary(List<AttendanceEntity> attendances) {
+        int present = countStatus(attendances, AttendanceStatus.PRESENT);
+        int absent = countStatus(attendances, AttendanceStatus.ABSENT);
+        int late = countStatus(attendances, AttendanceStatus.LATE);
+        int excused = countStatus(attendances, AttendanceStatus.EXCUSED);
+        int total = present + absent + late + excused;
+
+        return SessionAttendanceSummaryResponse.builder()
+                .present(present)
+                .absent(absent)
+                .late(late)
+                .excused(excused)
+                .total(total)
+                .build();
+    }
+
+    private int countStatus(List<AttendanceEntity> attendances, AttendanceStatus status) {
+        return (int) attendances.stream()
+                .filter(attendance -> attendance.getStatus() == status)
+                .count();
+    }
+
+    private boolean matchesDateFrom(SessionEntity session, LocalDate dateFrom) {
+        if (dateFrom == null) {
+            return true;
+        }
+        return !session.getDate().isBefore(dateFrom);
+    }
+
+    private boolean matchesDateTo(SessionEntity session, LocalDate dateTo) {
+        if (dateTo == null) {
+            return true;
+        }
+        return !session.getDate().isAfter(dateTo);
+    }
+
+    private LocalDateTime now() {
+        return LocalDateTime.now(KOREA_ZONE);
+    }
+}

--- a/src/main/java/com/prography/backend/domain/session/service/SessionService.java
+++ b/src/main/java/com/prography/backend/domain/session/service/SessionService.java
@@ -1,12 +1,18 @@
 package com.prography.backend.domain.session.service;
 
+import com.prography.backend.domain.cohort.entity.CohortEntity;
 import com.prography.backend.domain.session.entity.SessionEntity;
+import com.prography.backend.domain.session.entity.SessionStatus;
 import com.prography.backend.domain.session.repository.SessionRepository;
 import com.prography.backend.global.common.StatusCode;
 import com.prography.backend.global.error.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
 
 /**
  * packageName    : com.prography.backend.domain.session.service<br>
@@ -18,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
  * DATE              AUTHOR             NOTE<br>
  * -----------------------------------------------------------<br>
  * 2026-02-24         cod0216             최초생성<br>
+ * 2026-02-24         cod0216             일정 생성/수정/취소 기능 추가<br>
  */
 @Service
 @Transactional(readOnly = true)
@@ -26,8 +33,39 @@ public class SessionService {
 
     private final SessionRepository sessionRepository;
 
+    @Transactional
+    public SessionEntity create(CohortEntity cohort, String title, LocalDate date, LocalTime time, String location) {
+        SessionEntity session = SessionEntity.builder()
+                .cohort(cohort)
+                .title(title)
+                .date(date)
+                .time(time)
+                .location(location)
+                .status(SessionStatus.SCHEDULED)
+                .build();
+
+        return sessionRepository.save(session);
+    }
+
     public SessionEntity getById(Long id) {
         return sessionRepository.findById(id)
                 .orElseThrow(() -> new CustomException(StatusCode.SESSION_NOT_FOUND));
+    }
+
+    public List<SessionEntity> getByCohortId(Long cohortId) {
+        return sessionRepository.findByCohortIdOrderByDateAscTimeAsc(cohortId);
+    }
+
+    @Transactional
+    public SessionEntity update(SessionEntity session, String title, LocalDate date, LocalTime time, String location, SessionStatus status) {
+        session.updateInfo(title, date, time, location);
+        session.updateStatus(status);
+        return session;
+    }
+
+    @Transactional
+    public SessionEntity cancel(SessionEntity session) {
+        session.cancel();
+        return session;
     }
 }

--- a/src/main/java/com/prography/backend/global/common/PolicyConstants.java
+++ b/src/main/java/com/prography/backend/global/common/PolicyConstants.java
@@ -11,6 +11,7 @@ package com.prography.backend.global.common;
  * -----------------------------------------------------------<br>
  * 2026-02-25         cod0216             최초생성<br>
  * 2026-02-24         cod0216             출결 정책 상수 추가<br>
+ * 2026-02-24         cod0216             QR 유효기간 상수 추가<br>
  */
 public final class PolicyConstants {
 
@@ -25,4 +26,5 @@ public final class PolicyConstants {
     public static final long PENALTY_ABSENT = 10_000L;
     public static final long PENALTY_LATE_PER_MINUTE = 500L;
     public static final long PENALTY_MAX = 10_000L;
+    public static final int QR_EXPIRE_HOURS = 24;
 }

--- a/src/test/java/com/prography/backend/domain/qrcode/service/AdminQrCodeFacadeServiceTest.java
+++ b/src/test/java/com/prography/backend/domain/qrcode/service/AdminQrCodeFacadeServiceTest.java
@@ -1,0 +1,115 @@
+package com.prography.backend.domain.qrcode.service;
+
+import com.prography.backend.domain.cohort.entity.CohortEntity;
+import com.prography.backend.domain.cohort.repository.CohortRepository;
+import com.prography.backend.domain.qrcode.dto.response.QrCodeResponse;
+import com.prography.backend.domain.qrcode.entity.QrCodeEntity;
+import com.prography.backend.domain.qrcode.repository.QrCodeRepository;
+import com.prography.backend.domain.session.entity.SessionEntity;
+import com.prography.backend.domain.session.entity.SessionStatus;
+import com.prography.backend.domain.session.repository.SessionRepository;
+import com.prography.backend.global.common.PolicyConstants;
+import com.prography.backend.global.common.StatusCode;
+import com.prography.backend.global.error.CustomException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * packageName    : com.prography.backend.domain.qrcode.service<br>
+ * fileName       : AdminQrCodeFacadeServiceTest.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-25<br>
+ * description    : 관리자 QR 코드 파사드 서비스 테스트 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-25         cod0216             최초생성<br>
+ */
+@SpringBootTest
+@Transactional
+class AdminQrCodeFacadeServiceTest {
+
+    private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
+
+    @Autowired
+    private AdminQrCodeFacadeService adminQrCodeFacadeService;
+
+    @Autowired
+    private CohortRepository cohortRepository;
+
+    @Autowired
+    private SessionRepository sessionRepository;
+
+    @Autowired
+    private QrCodeRepository qrCodeRepository;
+
+    @Test
+    void createQrCode_activeExists_throwsConflict() {
+        // Given
+        SessionEntity session = createSession();
+        qrCodeRepository.save(QrCodeEntity.builder()
+                .session(session)
+                .hashValue("active-qr")
+                .expiresAt(now().plusHours(1))
+                .build());
+
+        // When & Then
+        assertThatThrownBy(() -> adminQrCodeFacadeService.createQrCode(session.getId()))
+                .isInstanceOf(CustomException.class)
+                .extracting("statusCode")
+                .isEqualTo(StatusCode.QR_ALREADY_ACTIVE);
+    }
+
+    @Test
+    void renewQrCode_expiresOldAndCreatesNew() {
+        // Given
+        SessionEntity session = createSession();
+        QrCodeEntity oldQr = qrCodeRepository.save(QrCodeEntity.builder()
+                .session(session)
+                .hashValue("old-qr")
+                .expiresAt(now().plusHours(2))
+                .build());
+
+        // When
+        QrCodeResponse renewed = adminQrCodeFacadeService.renewQrCode(oldQr.getId());
+
+        // Then
+        QrCodeEntity expiredOld = qrCodeRepository.findById(oldQr.getId()).orElseThrow();
+        QrCodeEntity newQr = qrCodeRepository.findById(renewed.getId()).orElseThrow();
+
+        assertThat(newQr.getId()).isNotEqualTo(oldQr.getId());
+        assertThat(expiredOld.getExpiresAt()).isBeforeOrEqualTo(now());
+        assertThat(newQr.getExpiresAt()).isAfter(expiredOld.getExpiresAt());
+        assertThat(newQr.getSession().getId()).isEqualTo(session.getId());
+    }
+
+    private SessionEntity createSession() {
+        CohortEntity cohort = cohortRepository.save(CohortEntity.builder()
+                .generation(PolicyConstants.CURRENT_GENERATION)
+                .name("11기")
+                .build());
+
+        return sessionRepository.save(SessionEntity.builder()
+                .cohort(cohort)
+                .title("정기 모임")
+                .date(LocalDate.of(2026, 2, 25))
+                .time(LocalTime.of(10, 0))
+                .location("강남")
+                .status(SessionStatus.SCHEDULED)
+                .build());
+    }
+
+    private LocalDateTime now() {
+        return LocalDateTime.now(KOREA_ZONE);
+    }
+}

--- a/src/test/java/com/prography/backend/domain/session/service/AdminSessionFacadeServiceTest.java
+++ b/src/test/java/com/prography/backend/domain/session/service/AdminSessionFacadeServiceTest.java
@@ -1,0 +1,199 @@
+package com.prography.backend.domain.session.service;
+
+import com.prography.backend.domain.attendance.entity.AttendanceStatus;
+import com.prography.backend.domain.attendance.service.AttendanceService;
+import com.prography.backend.domain.cohort.entity.CohortEntity;
+import com.prography.backend.domain.cohort.repository.CohortRepository;
+import com.prography.backend.domain.member.entity.MemberEntity;
+import com.prography.backend.domain.member.entity.MemberRole;
+import com.prography.backend.domain.member.service.MemberService;
+import com.prography.backend.domain.qrcode.entity.QrCodeEntity;
+import com.prography.backend.domain.qrcode.repository.QrCodeRepository;
+import com.prography.backend.domain.session.dto.request.AdminSessionCreateRequest;
+import com.prography.backend.domain.session.dto.request.AdminSessionUpdateRequest;
+import com.prography.backend.domain.session.dto.response.AdminSessionResponse;
+import com.prography.backend.domain.session.entity.SessionEntity;
+import com.prography.backend.domain.session.entity.SessionStatus;
+import com.prography.backend.domain.session.repository.SessionRepository;
+import com.prography.backend.global.common.PolicyConstants;
+import com.prography.backend.global.common.StatusCode;
+import com.prography.backend.global.error.CustomException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * packageName    : com.prography.backend.domain.session.service<br>
+ * fileName       : AdminSessionFacadeServiceTest.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-25<br>
+ * description    : 관리자 일정 파사드 서비스 테스트 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-25         cod0216             최초생성<br>
+ */
+@SpringBootTest
+@Transactional
+class AdminSessionFacadeServiceTest {
+
+    private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
+
+    @Autowired
+    private AdminSessionFacadeService adminSessionFacadeService;
+
+    @Autowired
+    private CohortRepository cohortRepository;
+
+    @Autowired
+    private SessionRepository sessionRepository;
+
+    @Autowired
+    private QrCodeRepository qrCodeRepository;
+
+    @Autowired
+    private AttendanceService attendanceService;
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Test
+    void createSession_createsQrCode() {
+        // Given
+        createCurrentCohort();
+        AdminSessionCreateRequest request = new AdminSessionCreateRequest();
+        setField(request, "title", "오리엔테이션");
+        setField(request, "date", LocalDate.of(2026, 2, 26));
+        setField(request, "time", LocalTime.of(19, 0));
+        setField(request, "location", "강남");
+
+        // When
+        AdminSessionResponse response = adminSessionFacadeService.createSession(request);
+
+        // Then
+        assertThat(response.isQrActive()).isTrue();
+        assertThat(qrCodeRepository.findFirstBySessionIdAndExpiresAtAfter(response.getId(), now())).isPresent();
+    }
+
+    @Test
+    void getSessions_includesAttendanceSummaryAndQrActive() {
+        // Given
+        CohortEntity cohort = createCurrentCohort();
+        SessionEntity session = createSession(cohort, SessionStatus.SCHEDULED);
+        MemberEntity member1 = createMember("session-list-1");
+        MemberEntity member2 = createMember("session-list-2");
+
+        attendanceService.create(session, member1, AttendanceStatus.PRESENT, null, 0L, null, now(), null);
+        attendanceService.create(session, member2, AttendanceStatus.LATE, 5, 2_500L, null, now(), null);
+        qrCodeRepository.save(QrCodeEntity.builder()
+                .session(session)
+                .hashValue("active-qr-list")
+                .expiresAt(now().plusHours(1))
+                .build());
+
+        // When
+        List<AdminSessionResponse> responses = adminSessionFacadeService.getSessions(null, null, null);
+
+        // Then
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).isQrActive()).isTrue();
+        assertThat(responses.get(0).getAttendanceSummary().getPresent()).isEqualTo(1);
+        assertThat(responses.get(0).getAttendanceSummary().getLate()).isEqualTo(1);
+        assertThat(responses.get(0).getAttendanceSummary().getTotal()).isEqualTo(2);
+    }
+
+    @Test
+    void updateSession_cancelledSession_throwsException() {
+        // Given
+        CohortEntity cohort = createCurrentCohort();
+        SessionEntity cancelled = createSession(cohort, SessionStatus.CANCELLED);
+        AdminSessionUpdateRequest request = new AdminSessionUpdateRequest();
+        setField(request, "title", "변경된 제목");
+        setField(request, "date", null);
+        setField(request, "time", null);
+        setField(request, "location", null);
+        setField(request, "status", SessionStatus.SCHEDULED);
+
+        // When & Then
+        assertThatThrownBy(() -> adminSessionFacadeService.updateSession(cancelled.getId(), request))
+                .isInstanceOf(CustomException.class)
+                .extracting("statusCode")
+                .isEqualTo(StatusCode.SESSION_ALREADY_CANCELLED);
+    }
+
+    @Test
+    void cancelSession_setsCancelledAndQrInactive() {
+        // Given
+        CohortEntity cohort = createCurrentCohort();
+        SessionEntity session = createSession(cohort, SessionStatus.SCHEDULED);
+        qrCodeRepository.save(QrCodeEntity.builder()
+                .session(session)
+                .hashValue("active-qr-cancel")
+                .expiresAt(now().plusHours(2))
+                .build());
+
+        // When
+        AdminSessionResponse response = adminSessionFacadeService.cancelSession(session.getId());
+
+        // Then
+        assertThat(response.getStatus()).isEqualTo(SessionStatus.CANCELLED);
+        assertThat(response.isQrActive()).isFalse();
+        assertThat(qrCodeRepository.findFirstBySessionIdAndExpiresAtAfter(session.getId(), now())).isNotPresent();
+    }
+
+    private CohortEntity createCurrentCohort() {
+        return cohortRepository.save(CohortEntity.builder()
+                .generation(PolicyConstants.CURRENT_GENERATION)
+                .name("11기")
+                .build());
+    }
+
+    private SessionEntity createSession(CohortEntity cohort, SessionStatus status) {
+        return sessionRepository.save(SessionEntity.builder()
+                .cohort(cohort)
+                .title("정기 모임")
+                .date(LocalDate.of(2026, 2, 25))
+                .time(LocalTime.of(10, 0))
+                .location("강남")
+                .status(status)
+                .build());
+    }
+
+    private MemberEntity createMember(String loginId) {
+        return memberService.createMember(
+                loginId,
+                passwordEncoder.encode("password123"),
+                "홍길동",
+                "010-1234-5678",
+                MemberRole.MEMBER
+        );
+    }
+
+    private LocalDateTime now() {
+        return LocalDateTime.now(KOREA_ZONE);
+    }
+
+    private void setField(Object target, String fieldName, Object value) {
+        try {
+            java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}


### PR DESCRIPTION
  ## #️⃣ 관련 이슈
- #11 

  ## 📝 작업 내용
  - 관리자 세션 조회/생성/수정/취소 API 추가
  - 관리자 QR 생성/갱신 API 추가
  - 세션/QR 도메인 로직 보강
  - 관리자 세션/QR 파사드 테스트 추가

  ## ✅ 테스트 결과
  - [x] ./gradlew test --tests "com.prography.backend.domain.session.service.AdminSessionFacadeServiceTest"
  - [x] ./gradlew test --tests "com.prography.backend.domain.qrcode.service.AdminQrCodeFacadeServiceTest"