### PR TITLE
feat: add member sessions api

### DIFF
--- a/src/main/java/com/prography/backend/domain/session/controller/SessionController.java
+++ b/src/main/java/com/prography/backend/domain/session/controller/SessionController.java
@@ -1,0 +1,37 @@
+package com.prography.backend.domain.session.controller;
+
+import com.prography.backend.domain.session.dto.response.MemberSessionResponse;
+import com.prography.backend.domain.session.service.MemberSessionFacadeService;
+import com.prography.backend.global.response.ApiResponse;
+import com.prography.backend.global.util.ResponseUtility;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * packageName    : com.prography.backend.domain.session.controller<br>
+ * fileName       : SessionController.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 회원 일정 API를 처리하는 컨트롤러 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/sessions")
+public class SessionController {
+
+    private final MemberSessionFacadeService memberSessionFacadeService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<MemberSessionResponse>>> getSessions() {
+        return ResponseUtility.success(memberSessionFacadeService.getSessions());
+    }
+}

--- a/src/main/java/com/prography/backend/domain/session/dto/response/MemberSessionResponse.java
+++ b/src/main/java/com/prography/backend/domain/session/dto/response/MemberSessionResponse.java
@@ -1,0 +1,33 @@
+package com.prography.backend.domain.session.dto.response;
+
+import com.prography.backend.domain.session.entity.SessionStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+/**
+ * packageName    : com.prography.backend.domain.session.dto.response<br>
+ * fileName       : MemberSessionResponse.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 회원 일정 응답 DTO 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Getter
+@Builder
+public class MemberSessionResponse {
+    private Long id;
+    private String title;
+    private LocalDate date;
+    private LocalTime time;
+    private String location;
+    private SessionStatus status;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/prography/backend/domain/session/mapper/SessionMapper.java
+++ b/src/main/java/com/prography/backend/domain/session/mapper/SessionMapper.java
@@ -1,6 +1,7 @@
 package com.prography.backend.domain.session.mapper;
 
 import com.prography.backend.domain.session.dto.response.AdminSessionResponse;
+import com.prography.backend.domain.session.dto.response.MemberSessionResponse;
 import com.prography.backend.domain.session.dto.response.SessionAttendanceSummaryResponse;
 import com.prography.backend.domain.session.entity.SessionEntity;
 import org.springframework.stereotype.Component;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Component;
  * DATE              AUTHOR             NOTE<br>
  * -----------------------------------------------------------<br>
  * 2026-02-24         cod0216             최초생성<br>
+ * 2026-02-24         cod0216             회원 일정 응답 매핑 추가<br>
  */
 @Component
 public class SessionMapper {
@@ -34,6 +36,23 @@ public class SessionMapper {
                 .status(session.getStatus())
                 .attendanceSummary(summary)
                 .qrActive(qrActive)
+                .createdAt(session.getCreatedAt())
+                .updatedAt(session.getUpdatedAt())
+                .build();
+    }
+
+    public MemberSessionResponse toMemberResponse(SessionEntity session) {
+        if (session == null) {
+            return null;
+        }
+
+        return MemberSessionResponse.builder()
+                .id(session.getId())
+                .title(session.getTitle())
+                .date(session.getDate())
+                .time(session.getTime())
+                .location(session.getLocation())
+                .status(session.getStatus())
                 .createdAt(session.getCreatedAt())
                 .updatedAt(session.getUpdatedAt())
                 .build();

--- a/src/main/java/com/prography/backend/domain/session/service/MemberSessionFacadeService.java
+++ b/src/main/java/com/prography/backend/domain/session/service/MemberSessionFacadeService.java
@@ -1,0 +1,42 @@
+package com.prography.backend.domain.session.service;
+
+import com.prography.backend.domain.cohort.entity.CohortEntity;
+import com.prography.backend.domain.cohort.service.CohortService;
+import com.prography.backend.domain.session.dto.response.MemberSessionResponse;
+import com.prography.backend.domain.session.entity.SessionStatus;
+import com.prography.backend.domain.session.mapper.SessionMapper;
+import com.prography.backend.global.common.PolicyConstants;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * packageName    : com.prography.backend.domain.session.service<br>
+ * fileName       : MemberSessionFacadeService.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 회원 일정 조회 API를 위한 파사드 서비스 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberSessionFacadeService {
+
+    private final CohortService cohortService;
+    private final SessionService sessionService;
+    private final SessionMapper sessionMapper;
+
+    public List<MemberSessionResponse> getSessions() {
+        CohortEntity cohort = cohortService.getByGeneration(PolicyConstants.CURRENT_GENERATION);
+        return sessionService.getByCohortId(cohort.getId()).stream()
+                .filter(session -> session.getStatus() != SessionStatus.CANCELLED)
+                .map(sessionMapper::toMemberResponse)
+                .toList();
+    }
+}

--- a/src/test/java/com/prography/backend/domain/session/service/MemberSessionFacadeServiceTest.java
+++ b/src/test/java/com/prography/backend/domain/session/service/MemberSessionFacadeServiceTest.java
@@ -1,0 +1,81 @@
+package com.prography.backend.domain.session.service;
+
+import com.prography.backend.domain.cohort.entity.CohortEntity;
+import com.prography.backend.domain.cohort.repository.CohortRepository;
+import com.prography.backend.domain.session.dto.response.MemberSessionResponse;
+import com.prography.backend.domain.session.entity.SessionEntity;
+import com.prography.backend.domain.session.entity.SessionStatus;
+import com.prography.backend.domain.session.repository.SessionRepository;
+import com.prography.backend.global.common.PolicyConstants;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * packageName    : com.prography.backend.domain.session.service<br>
+ * fileName       : MemberSessionFacadeServiceTest.java<br>
+ * author         : cod0216 <br>
+ * date           : 2026-02-24<br>
+ * description    : 회원 일정 파사드 서비스 테스트 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 2026-02-24         cod0216             최초생성<br>
+ */
+@SpringBootTest
+@Transactional
+class MemberSessionFacadeServiceTest {
+
+    @Autowired
+    private MemberSessionFacadeService memberSessionFacadeService;
+
+    @Autowired
+    private CohortRepository cohortRepository;
+
+    @Autowired
+    private SessionRepository sessionRepository;
+
+    @Test
+    void getSessions_excludesCancelledAndOtherCohort() {
+        // Given
+        CohortEntity current = createCohort(PolicyConstants.CURRENT_GENERATION);
+        CohortEntity old = createCohort(10);
+
+        SessionEntity included = createSession(current, SessionStatus.SCHEDULED, LocalDate.of(2026, 2, 25), LocalTime.of(10, 0));
+        createSession(current, SessionStatus.CANCELLED, LocalDate.of(2026, 2, 26), LocalTime.of(9, 0));
+        createSession(old, SessionStatus.SCHEDULED, LocalDate.of(2026, 2, 27), LocalTime.of(8, 0));
+
+        // When
+        List<MemberSessionResponse> responses = memberSessionFacadeService.getSessions();
+
+        // Then
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).getId()).isEqualTo(included.getId());
+        assertThat(responses.get(0).getStatus()).isEqualTo(SessionStatus.SCHEDULED);
+    }
+
+    private CohortEntity createCohort(int generation) {
+        return cohortRepository.save(CohortEntity.builder()
+                .generation(generation)
+                .name(generation + "기")
+                .build());
+    }
+
+    private SessionEntity createSession(CohortEntity cohort, SessionStatus status, LocalDate date, LocalTime time) {
+        return sessionRepository.save(SessionEntity.builder()
+                .cohort(cohort)
+                .title("정기 모임")
+                .date(date)
+                .time(time)
+                .location("강남")
+                .status(status)
+                .build());
+    }
+}


### PR DESCRIPTION
 ## #️⃣ 관련 이슈
- #13 

## 📝 작업 내용
- 회원 일정 목록 조회 API 추가
- CANCELLED 일정 제외 처리
- 회원 일정 파사드 테스트 추가

 ✅ 테스트 결과
- [x] ./gradlew test --tests "com.prography.backend.domain.session.service.MemberSessionFacadeServiceTest"